### PR TITLE
Add Sovereign Parking booking plugin

### DIFF
--- a/sovereign-parking/README.md
+++ b/sovereign-parking/README.md
@@ -1,0 +1,41 @@
+# Sovereign Parking Booking System
+
+A custom WordPress plugin that powers the Sovereign Parking cruise-terminal booking experience. It provides a multi-step customer checkout, real-time shuttle capacity enforcement, payment integrations, customer self-service portal, and a streamlined operations dashboard.
+
+## Key Features
+
+- **Multi-step booking form** with cruise selection, automatic date prefills, pricing matrix, shuttle slot enforcement, and payment options (Stripe, PayPal, Pay on Arrival deposit).
+- **Payment integrations** using Stripe Checkout and PayPal Orders. Pay-on-arrival bookings collect a configurable holding deposit.
+- **Automated email confirmations** matching the Sovereign Parking copy once payments (or deposits) succeed.
+- **Customer portal** that auto-creates accounts, lists bookings, and allows guests to update contact details, vehicle plates, or shuttle times.
+- **Operations dashboard** including booking management filters, CSV export, shuttle slot maintenance, cruise management, and a calendar overview.
+- **Customer credit ledger** to issue and redeem credits in lieu of refunds.
+
+## Installation
+
+1. Copy the `sovereign-parking` directory into your WordPress installation under `wp-content/plugins/`.
+2. Activate **Sovereign Parking Booking System** from the WordPress admin Plugins page.
+3. Configure payment credentials and email settings under **Sovereign Parking → Settings**.
+4. Create a page and add the `[sovereign_parking_booking]` shortcode for the booking form.
+5. Optionally add `[sovereign_parking_portal]` to a members-only page for the customer portal.
+
+## Requirements
+
+- WordPress 6.0 or newer.
+- PHP 7.4 or newer.
+- cURL support for outbound Stripe/PayPal API requests.
+
+## Shortcodes
+
+| Shortcode | Description |
+|-----------|-------------|
+| `[sovereign_parking_booking]` | Renders the customer booking flow. |
+| `[sovereign_parking_portal]` | Shows the self-service customer portal (requires login). |
+
+## Notes
+
+- Shuttle capacity defaults to 11 passengers per slot but can be edited via the Shuttle Slots post type.
+- Cruise schedules can be added individually or imported in bulk using the WordPress editor (CSV/XLSX import tooling can be added as needed).
+- Confirmation emails respect the provided copy and are only sent after successful payments or POA deposit collection.
+
+For further customisation or support, extend the service classes located in the `includes/` directory.

--- a/sovereign-parking/assets/css/admin.css
+++ b/sovereign-parking/assets/css/admin.css
@@ -1,0 +1,58 @@
+.sp-dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+    margin: 24px 0;
+}
+
+.sp-card {
+    background: #fff;
+    border-radius: 10px;
+    padding: 16px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.05);
+}
+
+.sp-card h2 {
+    margin-top: 0;
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.sp-metric {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #c9247b;
+    margin: 0;
+}
+
+.sp-calendar table.widefat td,
+.sp-calendar table.widefat th {
+    text-align: left;
+}
+
+.sp-calendar-filter {
+    display: flex;
+    gap: 12px;
+    align-items: flex-end;
+    margin-bottom: 16px;
+}
+
+.sp-calendar-filter label {
+    display: flex;
+    flex-direction: column;
+    font-weight: 600;
+}
+
+.sp-calendar-filter input[type="number"] {
+    width: 100px;
+}
+
+.sp-credit-actions {
+    margin-bottom: 24px;
+}
+
+.sp-credit-actions select,
+.sp-credit-actions input {
+    margin-right: 8px;
+}

--- a/sovereign-parking/assets/css/frontend.css
+++ b/sovereign-parking/assets/css/frontend.css
@@ -1,0 +1,185 @@
+.sp-booking-wrapper {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 10px 40px rgba(0,0,0,0.08);
+    margin: 24px auto;
+    max-width: 860px;
+}
+
+.sp-booking-form .sp-step {
+    display: none;
+}
+
+.sp-booking-form .sp-step.active {
+    display: block;
+}
+
+.sp-booking-form h2 {
+    margin-top: 0;
+    font-size: 1.4rem;
+}
+
+.sp-field {
+    margin-bottom: 16px;
+}
+
+.sp-field-group {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.sp-field-group .sp-field {
+    flex: 1 1 240px;
+}
+
+.sp-field label {
+    font-weight: 600;
+    display: block;
+    margin-bottom: 6px;
+}
+
+.sp-field input,
+.sp-field select {
+    width: 100%;
+    padding: 12px;
+    border-radius: 8px;
+    border: 1px solid #d4d7de;
+    font-size: 1rem;
+    background: #f9fafc;
+}
+
+.sp-field input:focus,
+.sp-field select:focus {
+    outline: none;
+    border-color: #c9247b;
+    box-shadow: 0 0 0 1px rgba(201,36,123,0.3);
+    background: #fff;
+}
+
+.sp-summary {
+    background: #f6f7fb;
+    border-radius: 10px;
+    padding: 16px 20px;
+    margin: 16px 0;
+}
+
+.sp-summary p {
+    margin: 4px 0;
+    font-weight: 600;
+}
+
+.sp-summary ul {
+    margin: 0;
+    padding-left: 20px;
+}
+
+.sp-summary li {
+    margin-bottom: 6px;
+}
+
+.sp-total-due {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #c9247b;
+}
+
+.sp-actions {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    margin-top: 24px;
+}
+
+.sp-actions .button-primary {
+    background: #c9247b;
+    border-color: #c9247b;
+    box-shadow: none;
+}
+
+.sp-actions .button-primary:hover {
+    background: #a81c64;
+    border-color: #a81c64;
+}
+
+.sp-chip {
+    border: none;
+    background: #f0f1f8;
+    color: #333;
+    padding: 6px 16px;
+    border-radius: 999px;
+    margin: 0 8px 12px 0;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.sp-chip.active,
+.sp-chip:hover {
+    background: #c9247b;
+    color: #fff;
+}
+
+.sp-note {
+    background: #fff6fa;
+    border-left: 4px solid #c9247b;
+    padding: 12px 16px;
+    border-radius: 8px;
+    margin-bottom: 16px;
+}
+
+.sp-note strong {
+    display: block;
+    margin-bottom: 4px;
+}
+
+.sp-fieldset {
+    border: 1px solid #e2e5ec;
+    padding: 16px;
+    border-radius: 8px;
+}
+
+.sp-radio {
+    display: block;
+    margin-bottom: 10px;
+    font-weight: 600;
+}
+
+.sp-processing {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 16px;
+}
+
+.sp-error {
+    color: #b12335;
+    font-weight: 600;
+}
+
+.sp-notice {
+    padding: 18px;
+    border-radius: 10px;
+    margin-bottom: 20px;
+}
+
+.sp-notice-success {
+    background: #f0fff5;
+    border: 1px solid #b6f1c5;
+}
+
+.sp-invalid {
+    border-color: #b12335 !important;
+}
+
+@media (max-width: 600px) {
+    .sp-booking-wrapper {
+        padding: 18px;
+    }
+    .sp-actions {
+        flex-direction: column;
+    }
+    .sp-field-group {
+        flex-direction: column;
+    }
+}

--- a/sovereign-parking/assets/css/portal.css
+++ b/sovereign-parking/assets/css/portal.css
@@ -1,0 +1,117 @@
+.sp-portal {
+    background: #fff;
+    padding: 24px;
+    border-radius: 12px;
+    box-shadow: 0 10px 35px rgba(0,0,0,0.06);
+    max-width: 960px;
+    margin: 24px auto;
+}
+
+.sp-portal h2 {
+    margin-top: 0;
+}
+
+.sp-portal-card {
+    border: 1px solid #e1e5ec;
+    border-radius: 10px;
+    padding: 20px;
+    margin-bottom: 20px;
+    background: #f8f9fd;
+}
+
+.sp-portal-card header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.sp-portal-card .sp-status {
+    background: #c9247b;
+    color: #fff;
+    padding: 4px 12px;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+}
+
+.sp-portal-card .sp-cruise {
+    font-weight: 600;
+    margin-bottom: 6px;
+}
+
+.sp-portal-card .sp-dates {
+    margin-top: 0;
+    color: #485066;
+}
+
+.sp-portal-form .sp-field {
+    margin-bottom: 14px;
+}
+
+.sp-portal-form label {
+    font-weight: 600;
+    display: block;
+    margin-bottom: 5px;
+}
+
+.sp-portal-form input,
+.sp-portal-form select {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ccd1db;
+    border-radius: 8px;
+    background: #fff;
+}
+
+.sp-portal-form input:focus,
+.sp-portal-form select:focus {
+    outline: none;
+    border-color: #c9247b;
+    box-shadow: 0 0 0 1px rgba(201,36,123,0.25);
+}
+
+.sp-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.sp-actions .button-primary {
+    background: #c9247b;
+    border-color: #c9247b;
+}
+
+.sp-message {
+    font-weight: 600;
+}
+
+.sp-message.success {
+    color: #1f8f5f;
+}
+
+.sp-message.error {
+    color: #b12335;
+}
+
+.sp-slot-error {
+    color: #b12335;
+    font-weight: 600;
+    margin-top: 6px;
+}
+
+.sp-portal-login {
+    max-width: 420px;
+    margin: 40px auto;
+    padding: 24px;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 12px 40px rgba(0,0,0,0.08);
+}
+
+@media (max-width: 600px) {
+    .sp-actions {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}

--- a/sovereign-parking/assets/js/frontend.js
+++ b/sovereign-parking/assets/js/frontend.js
@@ -1,0 +1,379 @@
+(function ($) {
+    'use strict';
+
+    const data = window.spBookingData || {};
+    const state = {
+        cruise: null,
+        entry: null,
+        exit: null,
+        days: 0,
+        price: 0,
+        passengers: 2,
+        shuttleDate: null,
+        shuttleId: null,
+        creditBalance: 0,
+        creditApplied: 0,
+    };
+
+    const $form = $('#sp-booking-form');
+    const $steps = $form.find('.sp-step');
+    let currentStep = 0;
+
+    function init() {
+        if (!$form.length) {
+            return;
+        }
+
+        populateCruises();
+        bindEvents();
+        updateStep();
+    }
+
+    function bindEvents() {
+        $form.on('click', '.sp-next', function () {
+            if (validateStep(currentStep)) {
+                currentStep++;
+                updateStep();
+            }
+        });
+
+        $form.on('click', '.sp-prev', function () {
+            currentStep = Math.max(0, currentStep - 1);
+            updateStep();
+        });
+
+        $('#sp-cruise-select').on('change', handleCruiseChange);
+        $('#sp-entry-date, #sp-exit-date').on('change', handleDateChange);
+        $('#sp-passengers, #sp-shuttle-date').on('change', refreshSlots);
+        $('#sp-shuttle-slot').on('change', function () {
+            state.shuttleId = $(this).val();
+        });
+        $('#sp-email').on('blur', fetchCreditBalance);
+        $('input[name="payment_method"]').on('change', togglePaymentNote);
+
+        $form.on('submit', handleSubmit);
+
+        togglePaymentNote();
+    }
+
+    function updateStep() {
+        $steps.removeClass('active').eq(currentStep).addClass('active');
+        $('html, body').animate({ scrollTop: $form.offset().top - 80 }, 200);
+        if (currentStep === 1) {
+            // Prefill shuttle date with entry date if available.
+            const entry = $('#sp-entry-date').val();
+            if (entry && !$('#sp-shuttle-date').val()) {
+                $('#sp-shuttle-date').val(entry.split('T')[0]);
+                state.shuttleDate = $('#sp-shuttle-date').val();
+                refreshSlots();
+            }
+        }
+        if (currentStep === 3) {
+            renderSummary();
+        }
+    }
+
+    function populateCruises() {
+        const $select = $('#sp-cruise-select');
+        const $filter = $('#sp-cruise-filter');
+        $select.empty().append('<option value="">' + sp_i18n('Select a cruise') + '</option>');
+
+        const lines = new Set();
+        data.cruises.forEach(cruise => {
+            lines.add(cruise.line || '');
+            $select.append('<option value="' + cruise.id + '" data-departure="' + cruise.departure + '" data-return="' + cruise.return + '">' + cruise.title + '</option>');
+        });
+
+        $filter.empty();
+        const $all = $('<button type="button" class="sp-chip active">' + sp_i18n('All Lines') + '</button>');
+        $all.on('click', function () {
+            $filter.find('.sp-chip').removeClass('active');
+            $(this).addClass('active');
+            $select.find('option').show();
+        });
+        $filter.append($all);
+
+        lines.forEach(line => {
+            if (!line) {
+                return;
+            }
+            const $chip = $('<button type="button" class="sp-chip">' + line + '</button>');
+            $chip.on('click', function () {
+                $filter.find('.sp-chip').removeClass('active');
+                $(this).addClass('active');
+                $select.find('option').each(function () {
+                    const optionLine = data.cruises.find(c => String(c.id) === $(this).val());
+                    if (!optionLine) {
+                        return;
+                    }
+                    if (optionLine.line === line) {
+                        $(this).show();
+                    } else if ($(this).val()) {
+                        $(this).hide();
+                    }
+                });
+                $select.val('');
+            });
+            $filter.append($chip);
+        });
+    }
+
+    function handleCruiseChange() {
+        const cruiseId = $(this).val();
+        state.cruise = cruiseId ? data.cruises.find(c => String(c.id) === cruiseId) : null;
+
+        if (state.cruise) {
+            if (state.cruise.departure) {
+                $('#sp-entry-date').val(toLocalInput(state.cruise.departure));
+            }
+            if (state.cruise.return) {
+                $('#sp-exit-date').val(toLocalInput(state.cruise.return));
+            }
+        }
+        handleDateChange();
+    }
+
+    function handleDateChange() {
+        const entry = $('#sp-entry-date').val();
+        const exit = $('#sp-exit-date').val();
+        state.entry = entry ? new Date(entry) : null;
+        state.exit = exit ? new Date(exit) : null;
+
+        if (state.entry && state.exit && state.exit >= state.entry) {
+            const diff = state.exit.getTime() - state.entry.getTime();
+            state.days = Math.ceil(diff / (1000 * 60 * 60 * 24));
+            if (state.days < 1) {
+                state.days = 1;
+            }
+        } else {
+            state.days = 0;
+        }
+        $('#sp-total-days').text(state.days);
+        updatePrice();
+    }
+
+    function updatePrice() {
+        const map = {};
+        if (Array.isArray(data.pricing)) {
+            data.pricing.forEach(row => {
+                map[row.days] = row.price;
+            });
+        }
+        let price = map[state.days] || 0;
+        const callQuote = state.days >= 30 || price === 0;
+        $('#sp-call-quote').prop('hidden', !callQuote);
+        if (callQuote) {
+            $('#sp-total-price').text('$0.00');
+            state.price = 0;
+            return;
+        }
+        state.price = price;
+        $('#sp-total-price').text(formatCurrency(price));
+    }
+
+    function refreshSlots() {
+        state.passengers = parseInt($('#sp-passengers').val(), 10) || 1;
+        state.shuttleDate = $('#sp-shuttle-date').val();
+        if (!state.shuttleDate || !state.passengers) {
+            return;
+        }
+
+        const payload = {
+            action: 'sp_get_slots',
+            nonce: data.nonce,
+            passengers: state.passengers,
+            date: state.shuttleDate,
+            cruise: state.cruise ? state.cruise.id : '',
+        };
+
+        const $select = $('#sp-shuttle-slot');
+        $select.prop('disabled', true);
+        $.post(data.ajaxUrl, payload, function (response) {
+            $select.empty();
+            if (!response.success || !response.data.length) {
+                $('#sp-slot-error').prop('hidden', false);
+                $select.prop('disabled', false);
+                return;
+            }
+            $('#sp-slot-error').prop('hidden', true);
+            response.data.forEach(slot => {
+                $select.append('<option value="' + slot.id + '">' + slot.label + ' (' + slot.remaining + ')</option>');
+            });
+            $select.prop('disabled', false);
+            state.shuttleId = $select.val();
+        });
+    }
+
+    function fetchCreditBalance() {
+        const email = $('#sp-email').val();
+        if (!email) {
+            return;
+        }
+        $.post(data.ajaxUrl, {
+            action: 'sp_get_credit',
+            nonce: data.nonce,
+            email: email
+        }, function (response) {
+            if (!response.success) {
+                $('#sp-credit-wrapper').prop('hidden', true);
+                return;
+            }
+            state.creditBalance = parseFloat(response.data.balance) || 0;
+            if (state.creditBalance > 0) {
+                $('#sp-credit-wrapper').prop('hidden', false);
+                $('#sp-credit-apply').attr('max', state.creditBalance.toFixed(2));
+                $('.sp-credit-balance').text(sp_i18n('Available credit: ') + formatCurrency(state.creditBalance));
+            } else {
+                $('#sp-credit-wrapper').prop('hidden', true);
+            }
+        });
+    }
+
+    function togglePaymentNote() {
+        const method = $('input[name="payment_method"]:checked').val();
+        $('.sp-poa-note').prop('hidden', method !== 'poa');
+    }
+
+    function renderSummary() {
+        const summary = $('#sp-checkout-summary');
+        const entry = $('#sp-entry-date').val();
+        const exit = $('#sp-exit-date').val();
+        const shuttleText = $('#sp-shuttle-slot option:selected').text();
+        const paymentMethod = $('input[name="payment_method"]:checked').val();
+        const passengers = state.passengers;
+        const credit = parseFloat($('#sp-credit-apply').val()) || 0;
+        state.creditApplied = Math.min(credit, state.creditBalance, state.price);
+
+        let totalDue = state.price - state.creditApplied;
+        let description = '';
+        if (paymentMethod === 'poa') {
+            totalDue = data.depositAmount || 10;
+            description = sp_i18n('Deposit payable now: ') + formatCurrency(totalDue);
+        } else {
+            description = sp_i18n('Amount payable now: ') + formatCurrency(totalDue);
+        }
+
+        const html = `
+            <h3>${sp_i18n('Booking Summary')}</h3>
+            <ul>
+                <li><strong>${sp_i18n('Cruise')}:</strong> ${$('#sp-cruise-select option:selected').text()}</li>
+                <li><strong>${sp_i18n('Entry')}:</strong> ${formatDisplayDate(entry)}</li>
+                <li><strong>${sp_i18n('Exit')}:</strong> ${formatDisplayDate(exit)}</li>
+                <li><strong>${sp_i18n('Passengers')}:</strong> ${passengers}</li>
+                <li><strong>${sp_i18n('Shuttle Slot')}:</strong> ${shuttleText}</li>
+                <li><strong>${sp_i18n('Parking Price')}:</strong> ${formatCurrency(state.price)}</li>
+                <li><strong>${sp_i18n('Credit Applied')}:</strong> ${formatCurrency(state.creditApplied)}</li>
+            </ul>
+            <p class="sp-total-due">${description}</p>
+        `;
+        summary.html(html);
+    }
+
+    function validateStep(step) {
+        let valid = true;
+        const $current = $steps.eq(step);
+        $current.find('[required]').each(function () {
+            if (!$(this).val()) {
+                $(this).addClass('sp-invalid');
+                valid = false;
+            } else {
+                $(this).removeClass('sp-invalid');
+            }
+        });
+
+        if (step === 0 && (state.days === 0 || state.price === 0)) {
+            valid = false;
+            $('#sp-total-price').addClass('sp-invalid');
+        }
+
+        if (step === 1 && !state.shuttleId) {
+            $('#sp-slot-error').prop('hidden', false);
+            valid = false;
+        }
+
+        return valid;
+    }
+
+    function handleSubmit(event) {
+        event.preventDefault();
+        if (!validateStep(currentStep)) {
+            return;
+        }
+
+        $('.sp-error-general').prop('hidden', true);
+        $('.sp-processing').prop('hidden', false);
+        $('.sp-submit').prop('disabled', true);
+
+        const payload = {
+            action: 'sp_create_booking',
+            nonce: data.nonce,
+            cruise_id: $('#sp-cruise-select').val(),
+            entry: $('#sp-entry-date').val(),
+            exit: $('#sp-exit-date').val(),
+            passengers: state.passengers,
+            shuttle_date: state.shuttleDate,
+            shuttle_id: state.shuttleId,
+            full_name: $('#sp-full-name').val(),
+            email: $('#sp-email').val(),
+            phone: $('#sp-phone').val(),
+            vehicle: $('#sp-vehicle').val(),
+            payment_method: $('input[name="payment_method"]:checked').val(),
+            credit: state.creditApplied,
+            source_url: window.location.href,
+        };
+
+        $.post(data.ajaxUrl, payload).done(function (response) {
+            if (!response || !response.success) {
+                const message = response && response.data && response.data.message ? response.data.message : sp_i18n('Unable to process booking. Please check your details and try again.');
+                $('.sp-error-general').text(message).prop('hidden', false);
+                return;
+            }
+
+            if (response.data.redirect_url) {
+                window.location.href = response.data.redirect_url;
+                return;
+            }
+
+            if (response.data.message) {
+                $('.sp-booking-wrapper').html('<div class="sp-notice sp-notice-success"><h3>' + sp_i18n('Booking Reserved') + '</h3><p>' + response.data.message + '</p></div>');
+            } else {
+                $('.sp-booking-wrapper').html('<div class="sp-notice sp-notice-success"><h3>' + sp_i18n('Booking Completed') + '</h3><p>' + sp_i18n('Thank you for booking with Sovereign Parking.') + '</p></div>');
+            }
+        }).fail(function () {
+            $('.sp-error-general').text(sp_i18n('An unexpected error occurred. Please try again.')).prop('hidden', false);
+        }).always(function () {
+            $('.sp-processing').prop('hidden', true);
+            $('.sp-submit').prop('disabled', false);
+        });
+    }
+
+    function toLocalInput(dateString) {
+        const date = new Date(dateString + 'Z');
+        if (isNaN(date.getTime())) {
+            return '';
+        }
+        const offsetDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+        return offsetDate.toISOString().slice(0, 16);
+    }
+
+    function formatCurrency(amount) {
+        return new Intl.NumberFormat('en-AU', { style: 'currency', currency: 'AUD' }).format(amount || 0);
+    }
+
+    function formatDisplayDate(value) {
+        if (!value) {
+            return '';
+        }
+        const date = new Date(value);
+        if (isNaN(date.getTime())) {
+            return value;
+        }
+        return date.toLocaleString();
+    }
+
+    function sp_i18n(text) {
+        return text;
+    }
+
+    $(document).ready(init);
+})(jQuery);

--- a/sovereign-parking/assets/js/portal.js
+++ b/sovereign-parking/assets/js/portal.js
@@ -1,0 +1,168 @@
+(function ($) {
+    'use strict';
+
+    const portal = window.spPortalData || {};
+    const $container = $('#sp-portal-bookings');
+
+    function init() {
+        if (!$container.length) {
+            return;
+        }
+        renderBookings();
+    }
+
+    function renderBookings() {
+        if (!portal.bookings || !portal.bookings.length) {
+            $container.html('<p>' + esc('You have no upcoming bookings at this time.') + '</p>');
+            return;
+        }
+
+        const cards = portal.bookings.map(renderCard);
+        $container.html(cards.join(''));
+
+        portal.bookings.forEach(booking => {
+            const $form = $('#sp-portal-form-' + booking.id);
+            $form.on('submit', function (event) {
+                event.preventDefault();
+                submitUpdate(booking.id);
+            });
+
+            $form.find('.sp-portal-shuttle-date').on('change', function () {
+                loadSlots(booking.id);
+            });
+
+            loadSlots(booking.id);
+        });
+    }
+
+    function renderCard(booking) {
+        const entry = booking.entry ? formatDate(booking.entry) : '';
+        const exit = booking.exit ? formatDate(booking.exit) : '';
+        const shuttleDate = booking.shuttle_date || '';
+        const status = booking.status ? booking.status.replace(/_/g, ' ') : '';
+
+        return `
+            <div class="sp-portal-card" id="sp-portal-card-${booking.id}">
+                <header>
+                    <h3>${esc('Booking #')}${booking.number}</h3>
+                    <span class="sp-status">${esc(status)}</span>
+                </header>
+                <p class="sp-cruise">${esc(booking.cruise)}</p>
+                <p class="sp-dates">${esc('Entry: ')}${esc(entry)}<br>${esc('Exit: ')}${esc(exit)}</p>
+                <form id="sp-portal-form-${booking.id}" class="sp-portal-form">
+                    <div class="sp-field">
+                        <label>${esc('Vehicle Number Plate')}</label>
+                        <input type="text" name="vehicle" value="${booking.vehicle ? escAttr(booking.vehicle) : ''}" />
+                    </div>
+                    <div class="sp-field">
+                        <label>${esc('Mobile Number')}</label>
+                        <input type="text" name="phone" value="${booking.phone ? escAttr(booking.phone) : ''}" />
+                    </div>
+                    <div class="sp-field">
+                        <label>${esc('Shuttle Date')}</label>
+                        <input type="date" class="sp-portal-shuttle-date" name="shuttle_date" value="${shuttleDate}" />
+                    </div>
+                    <div class="sp-field">
+                        <label>${esc('Shuttle Time Slot')}</label>
+                        <select name="shuttle_id" class="sp-portal-shuttle"></select>
+                        <p class="sp-slot-error" hidden>${esc('Selected shuttle time is full. Please choose another option.')}</p>
+                    </div>
+                    <div class="sp-actions">
+                        <button type="submit" class="button button-primary">${esc('Save Changes')}</button>
+                        <span class="sp-message" hidden></span>
+                    </div>
+                </form>
+            </div>
+        `;
+    }
+
+    function loadSlots(bookingId) {
+        const booking = portal.bookings.find(b => b.id === bookingId);
+        if (!booking) {
+            return;
+        }
+        const $card = $('#sp-portal-card-' + bookingId);
+        const $form = $('#sp-portal-form-' + bookingId);
+        const $select = $form.find('.sp-portal-shuttle');
+        const date = $form.find('.sp-portal-shuttle-date').val();
+        if (!date) {
+            $select.empty();
+            return;
+        }
+
+        const payload = {
+            action: 'sp_get_slots',
+            nonce: portal.nonce,
+            date: date,
+            passengers: booking.passengers,
+            booking_id: bookingId
+        };
+        $.post(portal.ajaxUrl, payload, function (response) {
+            $select.empty();
+            if (!response.success || !response.data.length) {
+                $form.find('.sp-slot-error').prop('hidden', false);
+                return;
+            }
+            $form.find('.sp-slot-error').prop('hidden', true);
+            response.data.forEach(slot => {
+                const option = $('<option></option>').attr('value', slot.id).text(slot.label + ' (' + slot.remaining + ')');
+                if (booking.shuttle_id && parseInt(booking.shuttle_id, 10) === parseInt(slot.id, 10)) {
+                    option.prop('selected', true);
+                }
+                $select.append(option);
+            });
+        });
+    }
+
+    function submitUpdate(bookingId) {
+        const $form = $('#sp-portal-form-' + bookingId);
+        const $message = $form.find('.sp-message');
+        const data = {
+            action: 'sp_update_booking',
+            nonce: portal.nonce,
+            booking_id: bookingId,
+            vehicle: $form.find('input[name="vehicle"]').val(),
+            phone: $form.find('input[name="phone"]').val(),
+            shuttle_id: $form.find('select[name="shuttle_id"]').val(),
+            shuttle_date: $form.find('input[name="shuttle_date"]').val(),
+        };
+
+        $message.prop('hidden', true).removeClass('success error');
+        $.post(portal.ajaxUrl, data, function (response) {
+            if (!response.success) {
+                $message.text(response.data && response.data.message ? response.data.message : portal.strings.updateError)
+                    .addClass('error').prop('hidden', false);
+                return;
+            }
+            const booking = portal.bookings.find(b => b.id === bookingId);
+            if (booking) {
+                booking.vehicle = data.vehicle;
+                booking.phone = data.phone;
+                booking.shuttle_id = data.shuttle_id;
+                booking.shuttle_date = data.shuttle_date;
+            }
+            $message.text(response.data && response.data.message ? response.data.message : portal.strings.updateSuccess)
+                .addClass('success').prop('hidden', false);
+        }).fail(function () {
+            $message.text(portal.strings.updateError).addClass('error').prop('hidden', false);
+        });
+    }
+
+    function formatDate(value) {
+        const date = new Date(value);
+        if (isNaN(date.getTime())) {
+            return value;
+        }
+        return date.toLocaleString();
+    }
+
+    function esc(text) {
+        return $('<div>').text(text || '').html();
+    }
+
+    function escAttr(text) {
+        return $('<div>').text(text || '').html();
+    }
+
+    $(document).ready(init);
+})(jQuery);

--- a/sovereign-parking/includes/class-sp-admin-bookings-list.php
+++ b/sovereign-parking/includes/class-sp-admin-bookings-list.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Enhancements for booking list table.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Admin_Bookings_List extends SP_Service {
+
+    /**
+     * Register hooks.
+     */
+    public function register_hooks() {
+        add_action( 'restrict_manage_posts', [ $this, 'filters' ] );
+        add_filter( 'parse_query', [ $this, 'apply_filters' ] );
+        add_filter( 'bulk_actions-edit-' . SP_Booking_CPT::POST_TYPE, [ $this, 'bulk_actions' ] );
+        add_filter( 'handle_bulk_actions-edit-' . SP_Booking_CPT::POST_TYPE, [ $this, 'handle_bulk_action' ], 10, 3 );
+    }
+
+    /**
+     * Render admin filters.
+     */
+    public function filters() {
+        global $typenow;
+        if ( SP_Booking_CPT::POST_TYPE !== $typenow ) {
+            return;
+        }
+
+        $cruises = get_posts(
+            [
+                'post_type'      => SP_Cruise_CPT::POST_TYPE,
+                'posts_per_page' => -1,
+                'post_status'    => 'publish',
+                'orderby'        => 'title',
+                'order'          => 'ASC',
+            ]
+        );
+
+        $selected_cruise = isset( $_GET['sp_cruise_filter'] ) ? intval( $_GET['sp_cruise_filter'] ) : '';
+        echo '<select name="sp_cruise_filter" class="postform">';
+        echo '<option value="">' . esc_html__( 'All Cruises', 'sovereign-parking' ) . '</option>';
+        foreach ( $cruises as $cruise ) {
+            printf( '<option value="%1$d" %2$s>%3$s</option>', esc_attr( $cruise->ID ), selected( $selected_cruise, $cruise->ID, false ), esc_html( $cruise->post_title ) );
+        }
+        echo '</select>';
+
+        $selected_status = isset( $_GET['sp_payment_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['sp_payment_filter'] ) ) : '';
+        $statuses        = [
+            'paid'         => __( 'Paid', 'sovereign-parking' ),
+            'pending'      => __( 'Pending', 'sovereign-parking' ),
+            'poa_pending'  => __( 'POA – Pending', 'sovereign-parking' ),
+            'poa_paid'     => __( 'POA – Paid', 'sovereign-parking' ),
+            'refunded'     => __( 'Refunded', 'sovereign-parking' ),
+        ];
+        echo '<select name="sp_payment_filter" class="postform">';
+        echo '<option value="">' . esc_html__( 'All Payment Statuses', 'sovereign-parking' ) . '</option>';
+        foreach ( $statuses as $key => $label ) {
+            printf( '<option value="%1$s" %2$s>%3$s</option>', esc_attr( $key ), selected( $selected_status, $key, false ), esc_html( $label ) );
+        }
+        echo '</select>';
+
+        $months = wp_get_archives(
+            [
+                'type'            => 'monthly',
+                'format'          => 'custom',
+                'post_type'       => SP_Booking_CPT::POST_TYPE,
+                'echo'            => 0,
+                'order'           => 'DESC',
+                'show_post_count' => false,
+            ]
+        );
+        // Default WP month dropdown already present; no further action.
+    }
+
+    /**
+     * Apply filters to query.
+     */
+    public function apply_filters( $query ) {
+        global $pagenow;
+        if ( 'edit.php' !== $pagenow || ! isset( $query->query['post_type'] ) || SP_Booking_CPT::POST_TYPE !== $query->query['post_type'] ) {
+            return;
+        }
+
+        if ( ! isset( $query->query_vars['meta_query'] ) || ! is_array( $query->query_vars['meta_query'] ) ) {
+            $query->query_vars['meta_query'] = [];
+        }
+
+        if ( ! empty( $_GET['sp_cruise_filter'] ) ) {
+            $query->query_vars['meta_query'][] = [
+                'key'   => '_sp_booking_cruise_id',
+                'value' => intval( $_GET['sp_cruise_filter'] ),
+            ];
+        }
+
+        if ( ! empty( $_GET['sp_payment_filter'] ) ) {
+            $query->query_vars['meta_query'][] = [
+                'key'   => '_sp_booking_payment_status',
+                'value' => sanitize_text_field( wp_unslash( $_GET['sp_payment_filter'] ) ),
+            ];
+        }
+    }
+
+    /**
+     * Register bulk actions.
+     */
+    public function bulk_actions( $actions ) {
+        $actions['sp_export_csv'] = __( 'Export to CSV', 'sovereign-parking' );
+        return $actions;
+    }
+
+    /**
+     * Handle bulk action.
+     */
+    public function handle_bulk_action( $redirect_to, $action, $post_ids ) {
+        if ( 'sp_export_csv' !== $action ) {
+            return $redirect_to;
+        }
+
+        $exporter = new SP_Admin_Export();
+        $exporter->stream_csv( $post_ids );
+        exit;
+    }
+}

--- a/sovereign-parking/includes/class-sp-admin-calendar.php
+++ b/sovereign-parking/includes/class-sp-admin-calendar.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Calendar admin controller.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Admin_Calendar extends SP_Service {
+
+    /**
+     * Register hooks.
+     */
+    public function register_hooks() {
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+    }
+
+    /**
+     * Enqueue assets on calendar page.
+     */
+    public function enqueue_assets( $hook ) {
+        if ( 'toplevel_page_sovereign-parking' === $hook || 'sovereign-parking_page_sp-calendar' === $hook ) {
+            wp_enqueue_style( 'sp-admin', SP_PLUGIN_URL . 'assets/css/admin.css', [], SP_PLUGIN_VERSION );
+        }
+    }
+}

--- a/sovereign-parking/includes/class-sp-admin-export.php
+++ b/sovereign-parking/includes/class-sp-admin-export.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Export utilities.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Admin_Export extends SP_Service {
+
+    /**
+     * Register hooks.
+     */
+    public function register_hooks() {
+        add_action( 'admin_post_sp_export_filtered', [ $this, 'export_filtered' ] );
+    }
+
+    /**
+     * Stream CSV for given booking IDs.
+     */
+    public function stream_csv( $post_ids ) {
+        if ( empty( $post_ids ) ) {
+            wp_die( esc_html__( 'No bookings selected.', 'sovereign-parking' ) );
+        }
+
+        $filename = 'sovereign-bookings-' . gmdate( 'Ymd-His' ) . '.csv';
+        header( 'Content-Type: text/csv' );
+        header( 'Content-Disposition: attachment; filename=' . $filename );
+
+        $output = fopen( 'php://output', 'w' );
+        fputcsv( $output, [ 'Booking ID', 'Customer', 'Email', 'Phone', 'Number Plate', 'Cruise', 'Entry', 'Exit', 'Days', 'Shuttle Slot', 'Passengers', 'Payment Method', 'Payment Status', 'Amount', 'Credit Applied', 'Notes' ] );
+
+        foreach ( $post_ids as $post_id ) {
+            $customer_name = get_post_field( 'post_title', $post_id );
+            $email         = get_post_meta( $post_id, '_sp_booking_email', true );
+            $phone         = get_post_meta( $post_id, '_sp_booking_phone', true );
+            $vehicle       = get_post_meta( $post_id, '_sp_booking_vehicle', true );
+            $cruise_id     = get_post_meta( $post_id, '_sp_booking_cruise_id', true );
+            $cruise_title  = $cruise_id ? get_the_title( $cruise_id ) : '';
+            $entry         = get_post_meta( $post_id, '_sp_booking_entry', true );
+            $exit          = get_post_meta( $post_id, '_sp_booking_exit', true );
+            $days          = get_post_meta( $post_id, '_sp_booking_days', true );
+            $slot_id       = get_post_meta( $post_id, '_sp_booking_shuttle_id', true );
+            $slot_title    = $slot_id ? get_the_title( $slot_id ) : '';
+            $passengers    = get_post_meta( $post_id, '_sp_booking_passengers', true );
+            $payment       = get_post_meta( $post_id, '_sp_booking_payment', true );
+            $payment_status= get_post_meta( $post_id, '_sp_booking_payment_status', true );
+            $amount        = get_post_meta( $post_id, '_sp_booking_amount', true );
+            $credit        = get_post_meta( $post_id, '_sp_booking_credit_used', true );
+            $notes         = get_post_meta( $post_id, '_sp_booking_notes', true );
+
+            fputcsv(
+                $output,
+                [
+                    get_post_meta( $post_id, '_sp_booking_number', true ),
+                    $customer_name,
+                    $email,
+                    $phone,
+                    $vehicle,
+                    $cruise_title,
+                    $entry,
+                    $exit,
+                    $days,
+                    $slot_title,
+                    $passengers,
+                    $payment,
+                    $payment_status,
+                    $amount,
+                    $credit,
+                    $notes,
+                ]
+            );
+        }
+
+        fclose( $output );
+    }
+
+    /**
+     * Export filtered bookings.
+     */
+    public function export_filtered() {
+        if ( ! current_user_can( 'edit_sp_bookings' ) ) {
+            wp_die( esc_html__( 'Permission denied.', 'sovereign-parking' ) );
+        }
+
+        check_admin_referer( 'sp_export_filtered' );
+
+        $args = [
+            'post_type'      => SP_Booking_CPT::POST_TYPE,
+            'posts_per_page' => -1,
+        ];
+
+        if ( ! empty( $_GET['sp_cruise_filter'] ) ) {
+            $args['meta_query'][] = [
+                'key'   => '_sp_booking_cruise_id',
+                'value' => intval( $_GET['sp_cruise_filter'] ),
+            ];
+        }
+
+        if ( ! empty( $_GET['sp_payment_filter'] ) ) {
+            $args['meta_query'][] = [
+                'key'   => '_sp_booking_payment_status',
+                'value' => sanitize_text_field( wp_unslash( $_GET['sp_payment_filter'] ) ),
+            ];
+        }
+
+        $posts = get_posts( $args );
+        $ids   = wp_list_pluck( $posts, 'ID' );
+        $this->stream_csv( $ids );
+        exit;
+    }
+}

--- a/sovereign-parking/includes/class-sp-admin-menu.php
+++ b/sovereign-parking/includes/class-sp-admin-menu.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Admin menu registration.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Admin_Menu extends SP_Service {
+
+    /**
+     * Register hooks.
+     */
+    public function register_hooks() {
+        add_action( 'admin_menu', [ $this, 'register_menu' ] );
+    }
+
+    /**
+     * Add admin menu entries.
+     */
+    public function register_menu() {
+        add_menu_page(
+            __( 'Sovereign Parking', 'sovereign-parking' ),
+            __( 'Sovereign Parking', 'sovereign-parking' ),
+            'edit_sp_bookings',
+            'sovereign-parking',
+            [ $this, 'render_dashboard' ],
+            'dashicons-parking',
+            56
+        );
+
+        add_submenu_page( 'sovereign-parking', __( 'Dashboard', 'sovereign-parking' ), __( 'Dashboard', 'sovereign-parking' ), 'edit_sp_bookings', 'sovereign-parking', [ $this, 'render_dashboard' ] );
+        add_submenu_page( 'sovereign-parking', __( 'Bookings', 'sovereign-parking' ), __( 'Bookings', 'sovereign-parking' ), 'edit_sp_bookings', 'edit.php?post_type=' . SP_Booking_CPT::POST_TYPE );
+        add_submenu_page( 'sovereign-parking', __( 'Cruises', 'sovereign-parking' ), __( 'Cruises', 'sovereign-parking' ), 'edit_sp_bookings', 'edit.php?post_type=' . SP_Cruise_CPT::POST_TYPE );
+        add_submenu_page( 'sovereign-parking', __( 'Shuttle Slots', 'sovereign-parking' ), __( 'Shuttle Slots', 'sovereign-parking' ), 'edit_sp_bookings', 'edit.php?post_type=' . SP_Shuttle_Slot_CPT::POST_TYPE );
+        add_submenu_page( 'sovereign-parking', __( 'Calendar', 'sovereign-parking' ), __( 'Calendar', 'sovereign-parking' ), 'edit_sp_bookings', 'sp-calendar', [ $this, 'render_calendar' ] );
+        add_submenu_page( 'sovereign-parking', __( 'Customer Credits', 'sovereign-parking' ), __( 'Customer Credits', 'sovereign-parking' ), 'edit_sp_bookings', 'sp-credits', [ $this, 'render_credits' ] );
+        add_submenu_page( 'sovereign-parking', __( 'Settings', 'sovereign-parking' ), __( 'Settings', 'sovereign-parking' ), 'manage_sp_settings', 'sp-settings', [ $this, 'render_settings' ] );
+    }
+
+    /**
+     * Render dashboard summary.
+     */
+    public function render_dashboard() {
+        $bookings_count = wp_count_posts( SP_Booking_CPT::POST_TYPE );
+        $confirmed      = isset( $bookings_count->{'sp-confirmed'} ) ? intval( $bookings_count->{'sp-confirmed'} ) : 0;
+        $pending        = isset( $bookings_count->{'sp-pending'} ) ? intval( $bookings_count->{'sp-pending'} ) : 0;
+        $poa_pending    = isset( $bookings_count->{'sp-poa-pending'} ) ? intval( $bookings_count->{'sp-poa-pending'} ) : 0;
+        $poa_paid       = isset( $bookings_count->{'sp-poa-paid'} ) ? intval( $bookings_count->{'sp-poa-paid'} ) : 0;
+        $total          = array_sum( (array) $bookings_count );
+        include SP_PLUGIN_DIR . 'templates/admin/dashboard.php';
+    }
+
+    /**
+     * Render settings page.
+     */
+    public function render_settings() {
+        if ( ! current_user_can( 'manage_sp_settings' ) ) {
+            wp_die( esc_html__( 'You do not have permission to access this page.', 'sovereign-parking' ) );
+        }
+        include SP_PLUGIN_DIR . 'templates/admin/settings.php';
+    }
+
+    /**
+     * Render calendar.
+     */
+    public function render_calendar() {
+        include SP_PLUGIN_DIR . 'templates/admin/calendar.php';
+    }
+
+    /**
+     * Render credits page.
+     */
+    public function render_credits() {
+        include SP_PLUGIN_DIR . 'templates/admin/credits.php';
+    }
+}

--- a/sovereign-parking/includes/class-sp-ajax-controller.php
+++ b/sovereign-parking/includes/class-sp-ajax-controller.php
@@ -1,0 +1,336 @@
+<?php
+/**
+ * AJAX endpoints for booking workflow.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Ajax_Controller extends SP_Service {
+
+    /**
+     * Register hooks.
+     */
+    public function register_hooks() {
+        add_action( 'wp_ajax_sp_get_slots', [ $this, 'get_slots' ] );
+        add_action( 'wp_ajax_nopriv_sp_get_slots', [ $this, 'get_slots' ] );
+
+        add_action( 'wp_ajax_sp_get_credit', [ $this, 'get_credit' ] );
+        add_action( 'wp_ajax_nopriv_sp_get_credit', [ $this, 'get_credit' ] );
+
+        add_action( 'wp_ajax_sp_create_booking', [ $this, 'create_booking' ] );
+        add_action( 'wp_ajax_nopriv_sp_create_booking', [ $this, 'create_booking' ] );
+
+        add_action( 'wp_ajax_sp_update_booking', [ $this, 'update_booking' ] );
+    }
+
+    /**
+     * Validate nonce for requests.
+     */
+    protected function verify_nonce() {
+        if ( empty( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'sp_booking_nonce' ) ) {
+            wp_send_json_error( [ 'message' => __( 'Security check failed. Refresh and try again.', 'sovereign-parking' ) ], 403 );
+        }
+    }
+
+    /**
+     * Fetch available shuttle slots based on passengers and date.
+     */
+    public function get_slots() {
+        $this->verify_nonce();
+
+        $passengers = isset( $_POST['passengers'] ) ? intval( $_POST['passengers'] ) : 0;
+        $date       = isset( $_POST['date'] ) ? sanitize_text_field( wp_unslash( $_POST['date'] ) ) : '';
+        $booking_id = isset( $_POST['booking_id'] ) ? intval( $_POST['booking_id'] ) : 0;
+
+        if ( $passengers <= 0 || empty( $date ) ) {
+            wp_send_json_error( [ 'message' => __( 'Missing shuttle information.', 'sovereign-parking' ) ] );
+        }
+
+        $slots = get_posts(
+            [
+                'post_type'      => SP_Shuttle_Slot_CPT::POST_TYPE,
+                'post_status'    => 'publish',
+                'posts_per_page' => -1,
+                'orderby'        => 'meta_value',
+                'meta_key'       => '_sp_slot_start',
+                'order'          => 'ASC',
+            ]
+        );
+
+        $available = [];
+        foreach ( $slots as $slot ) {
+            $capacity  = (int) get_post_meta( $slot->ID, '_sp_slot_capacity', true );
+            $booked    = $this->get_slot_passengers( $slot->ID, $date, $booking_id );
+            $remaining = max( 0, $capacity - $booked );
+            if ( $remaining >= $passengers ) {
+                $available[] = [
+                    'id'        => $slot->ID,
+                    'label'     => $slot->post_title,
+                    'remaining' => $remaining,
+                ];
+            }
+        }
+
+        wp_send_json_success( $available );
+    }
+
+    /**
+     * Retrieve remaining passengers for slot/date.
+     */
+    protected function get_slot_passengers( $slot_id, $date, $exclude_booking = 0 ) {
+        $bookings = get_posts(
+            [
+                'post_type'      => SP_Booking_CPT::POST_TYPE,
+                'post_status'    => [ 'sp-confirmed', 'sp-poa-pending', 'sp-poa-paid', 'sp-pending' ],
+                'posts_per_page' => -1,
+                'fields'         => 'ids',
+                'meta_query'     => [
+                    [
+                        'key'   => '_sp_booking_shuttle_id',
+                        'value' => $slot_id,
+                    ],
+                    [
+                        'key'   => '_sp_booking_shuttle_date',
+                        'value' => $date,
+                    ],
+                ],
+            ]
+        );
+
+        $total = 0;
+        foreach ( $bookings as $booking_id ) {
+            if ( $exclude_booking && intval( $booking_id ) === intval( $exclude_booking ) ) {
+                continue;
+            }
+            $total += (int) get_post_meta( $booking_id, '_sp_booking_passengers', true );
+        }
+        return $total;
+    }
+
+    /**
+     * Fetch customer credit balance.
+     */
+    public function get_credit() {
+        $this->verify_nonce();
+        $email = isset( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : '';
+        if ( empty( $email ) ) {
+            wp_send_json_error();
+        }
+
+        $user = get_user_by( 'email', $email );
+        if ( ! $user ) {
+            wp_send_json_success( [ 'balance' => 0 ] );
+        }
+
+        $balance = SP_Customer_Credits::instance()->get_balance( $user->ID );
+        wp_send_json_success( [ 'balance' => $balance ] );
+    }
+
+    /**
+     * Create booking and initiate payment.
+     */
+    public function create_booking() {
+        $this->verify_nonce();
+
+        $cruise_id     = isset( $_POST['cruise_id'] ) ? intval( $_POST['cruise_id'] ) : 0;
+        $entry_raw     = isset( $_POST['entry'] ) ? sanitize_text_field( wp_unslash( $_POST['entry'] ) ) : '';
+        $exit_raw      = isset( $_POST['exit'] ) ? sanitize_text_field( wp_unslash( $_POST['exit'] ) ) : '';
+        $passengers    = isset( $_POST['passengers'] ) ? intval( $_POST['passengers'] ) : 0;
+        $shuttle_id    = isset( $_POST['shuttle_id'] ) ? intval( $_POST['shuttle_id'] ) : 0;
+        $shuttle_date  = isset( $_POST['shuttle_date'] ) ? sanitize_text_field( wp_unslash( $_POST['shuttle_date'] ) ) : '';
+        $full_name     = isset( $_POST['full_name'] ) ? sanitize_text_field( wp_unslash( $_POST['full_name'] ) ) : '';
+        $email         = isset( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : '';
+        $phone         = isset( $_POST['phone'] ) ? sanitize_text_field( wp_unslash( $_POST['phone'] ) ) : '';
+        $vehicle       = isset( $_POST['vehicle'] ) ? sanitize_text_field( wp_unslash( $_POST['vehicle'] ) ) : '';
+        $payment       = isset( $_POST['payment_method'] ) ? sanitize_text_field( wp_unslash( $_POST['payment_method'] ) ) : 'stripe';
+        $credit_apply  = isset( $_POST['credit'] ) ? floatval( $_POST['credit'] ) : 0;
+        $source_url    = isset( $_POST['source_url'] ) ? esc_url_raw( wp_unslash( $_POST['source_url'] ) ) : home_url( '/' );
+
+        if ( ! $cruise_id || empty( $entry_raw ) || empty( $exit_raw ) || $passengers <= 0 || ! $shuttle_id || empty( $shuttle_date ) ) {
+            wp_send_json_error( [ 'message' => __( 'Please complete all required fields.', 'sovereign-parking' ) ] );
+        }
+
+        $entry = SP_Helpers::sanitize_datetime( $entry_raw );
+        $exit  = SP_Helpers::sanitize_datetime( $exit_raw );
+        if ( empty( $entry ) || empty( $exit ) ) {
+            wp_send_json_error( [ 'message' => __( 'Invalid entry/exit dates.', 'sovereign-parking' ) ] );
+        }
+
+        $days  = SP_Helpers::calculate_days( $entry, $exit );
+        $price = SP_Helpers::calculate_price( $days );
+        if ( $price <= 0 ) {
+            wp_send_json_error( [ 'message' => __( 'For stays of 30 days or more please contact us for a quote.', 'sovereign-parking' ) ] );
+        }
+
+        $remaining_capacity = $this->get_slot_passengers( $shuttle_id, $shuttle_date );
+        $capacity           = (int) get_post_meta( $shuttle_id, '_sp_slot_capacity', true );
+        if ( $remaining_capacity + $passengers > $capacity ) {
+            wp_send_json_error( [ 'message' => __( 'Selected shuttle slot is no longer available. Please choose another time.', 'sovereign-parking' ) ] );
+        }
+
+        $user = get_user_by( 'email', $email );
+        if ( ! $user ) {
+            $user_id = wp_insert_user(
+                [
+                    'user_login' => sanitize_user( current( explode( '@', $email ) ) . wp_generate_password( 4, false ) ),
+                    'user_email' => $email,
+                    'user_pass'  => wp_generate_password( 12, true ),
+                    'display_name' => $full_name,
+                    'first_name' => $full_name,
+                    'role'       => SP_Roles::ROLE_CUSTOMER,
+                ]
+            );
+
+            if ( is_wp_error( $user_id ) ) {
+                wp_send_json_error( [ 'message' => __( 'Could not create customer account.', 'sovereign-parking' ) ] );
+            }
+            $user = get_user_by( 'id', $user_id );
+            wp_new_user_notification( $user_id, null, 'user' );
+        } else {
+            $user_id = $user->ID;
+            if ( ! in_array( SP_Roles::ROLE_CUSTOMER, (array) $user->roles, true ) ) {
+                $user->add_role( SP_Roles::ROLE_CUSTOMER );
+            }
+        }
+
+        update_user_meta( $user_id, 'phone', $phone );
+
+        $credit_balance = SP_Customer_Credits::instance()->get_balance( $user_id );
+        $credit_applied = min( max( $credit_apply, 0 ), $credit_balance, $price );
+        $amount_due     = max( 0, $price - $credit_applied );
+
+        $booking_id = wp_insert_post(
+            [
+                'post_type'   => SP_Booking_CPT::POST_TYPE,
+                'post_status' => 'sp-pending',
+                'post_title'  => $full_name,
+                'post_excerpt'=> sprintf( 'Cruise %s from %s to %s', get_the_title( $cruise_id ), $entry, $exit ),
+            ]
+        );
+
+        if ( is_wp_error( $booking_id ) ) {
+            wp_send_json_error( [ 'message' => __( 'Could not create booking. Please try again.', 'sovereign-parking' ) ] );
+        }
+
+        $booking_number = SP_Helpers::generate_booking_number();
+        update_post_meta( $booking_id, '_sp_booking_number', $booking_number );
+        update_post_meta( $booking_id, '_sp_booking_user_id', $user_id );
+        update_post_meta( $booking_id, '_sp_booking_cruise_id', $cruise_id );
+        update_post_meta( $booking_id, '_sp_booking_entry', $entry );
+        update_post_meta( $booking_id, '_sp_booking_exit', $exit );
+        update_post_meta( $booking_id, '_sp_booking_days', $days );
+        update_post_meta( $booking_id, '_sp_booking_passengers', $passengers );
+        update_post_meta( $booking_id, '_sp_booking_shuttle_id', $shuttle_id );
+        update_post_meta( $booking_id, '_sp_booking_shuttle_date', $shuttle_date );
+        update_post_meta( $booking_id, '_sp_booking_amount', $price );
+        update_post_meta( $booking_id, '_sp_booking_payment', $payment );
+        update_post_meta( $booking_id, '_sp_booking_payment_status', 'pending' );
+        update_post_meta( $booking_id, '_sp_booking_credit_used', $credit_applied );
+        update_post_meta( $booking_id, '_sp_booking_vehicle', $vehicle );
+        update_post_meta( $booking_id, '_sp_booking_phone', $phone );
+        update_post_meta( $booking_id, '_sp_booking_email', $email );
+        update_post_meta( $booking_id, '_sp_booking_source_url', $source_url );
+
+        if ( $credit_applied > 0 ) {
+            SP_Customer_Credits::instance()->deduct_credit( $user_id, $credit_applied, $booking_id );
+        }
+
+        if ( 'poa' === $payment ) {
+            $deposit = (float) SP_Helpers::get_option( 'poa_deposit_amount', 10 );
+            update_post_meta( $booking_id, '_sp_booking_hold_amount', $deposit );
+            update_post_meta( $booking_id, '_sp_booking_payment_status', 'poa_pending' );
+            wp_update_post( [ 'ID' => $booking_id, 'post_status' => 'sp-poa-pending' ] );
+
+            $session = SP_Payment_Stripe::instance()->create_checkout_session( $booking_id, $deposit, 'deposit', $source_url );
+            if ( is_wp_error( $session ) ) {
+                wp_delete_post( $booking_id, true );
+                wp_send_json_error( [ 'message' => $session->get_error_message() ] );
+            }
+
+            wp_send_json_success( [ 'redirect_url' => $session['url'] ] );
+        }
+
+        if ( $amount_due <= 0 ) {
+            update_post_meta( $booking_id, '_sp_booking_payment_status', 'paid' );
+            wp_update_post( [ 'ID' => $booking_id, 'post_status' => 'sp-confirmed' ] );
+            do_action( 'sp_booking_payment_confirmed', $booking_id );
+            wp_send_json_success( [ 'message' => __( 'Booking confirmed using credit balance.', 'sovereign-parking' ) ] );
+        }
+
+        if ( 'paypal' === $payment ) {
+            $order = SP_Payment_Paypal::instance()->create_order( $booking_id, $amount_due, $source_url );
+            if ( is_wp_error( $order ) ) {
+                wp_delete_post( $booking_id, true );
+                wp_send_json_error( [ 'message' => $order->get_error_message() ] );
+            }
+
+            wp_send_json_success( [ 'redirect_url' => $order['url'] ] );
+        }
+
+        // Default to Stripe full payment.
+        $session = SP_Payment_Stripe::instance()->create_checkout_session( $booking_id, $amount_due, 'full', $source_url );
+        if ( is_wp_error( $session ) ) {
+            wp_delete_post( $booking_id, true );
+            wp_send_json_error( [ 'message' => $session->get_error_message() ] );
+        }
+
+        wp_send_json_success( [ 'redirect_url' => $session['url'] ] );
+    }
+
+    /**
+     * Update booking details from portal.
+     */
+    public function update_booking() {
+        $this->verify_nonce();
+
+        if ( ! is_user_logged_in() ) {
+            wp_send_json_error( [ 'message' => __( 'You must be logged in to update bookings.', 'sovereign-parking' ) ], 401 );
+        }
+
+        $booking_id   = isset( $_POST['booking_id'] ) ? intval( $_POST['booking_id'] ) : 0;
+        $vehicle      = isset( $_POST['vehicle'] ) ? sanitize_text_field( wp_unslash( $_POST['vehicle'] ) ) : '';
+        $phone        = isset( $_POST['phone'] ) ? sanitize_text_field( wp_unslash( $_POST['phone'] ) ) : '';
+        $shuttle_id   = isset( $_POST['shuttle_id'] ) ? intval( $_POST['shuttle_id'] ) : 0;
+        $shuttle_date = isset( $_POST['shuttle_date'] ) ? sanitize_text_field( wp_unslash( $_POST['shuttle_date'] ) ) : '';
+
+        if ( ! $booking_id ) {
+            wp_send_json_error( [ 'message' => __( 'Booking not found.', 'sovereign-parking' ) ] );
+        }
+
+        $booking = get_post( $booking_id );
+        if ( ! $booking || SP_Booking_CPT::POST_TYPE !== $booking->post_type ) {
+            wp_send_json_error( [ 'message' => __( 'Invalid booking.', 'sovereign-parking' ) ] );
+        }
+
+        $user_id = get_current_user_id();
+        $owner   = (int) get_post_meta( $booking_id, '_sp_booking_user_id', true );
+        if ( $owner !== $user_id ) {
+            wp_send_json_error( [ 'message' => __( 'You are not authorised to update this booking.', 'sovereign-parking' ) ], 403 );
+        }
+
+        if ( $shuttle_id && $shuttle_date ) {
+            $passengers = (int) get_post_meta( $booking_id, '_sp_booking_passengers', true );
+            $capacity   = (int) get_post_meta( $shuttle_id, '_sp_slot_capacity', true );
+            $booked     = $this->get_slot_passengers( $shuttle_id, $shuttle_date, $booking_id );
+            if ( $booked + $passengers > $capacity ) {
+                wp_send_json_error( [ 'message' => __( 'Selected shuttle time no longer has capacity.', 'sovereign-parking' ) ] );
+            }
+            update_post_meta( $booking_id, '_sp_booking_shuttle_id', $shuttle_id );
+            update_post_meta( $booking_id, '_sp_booking_shuttle_date', $shuttle_date );
+        }
+
+        if ( $vehicle ) {
+            update_post_meta( $booking_id, '_sp_booking_vehicle', $vehicle );
+        }
+        if ( $phone ) {
+            update_post_meta( $booking_id, '_sp_booking_phone', $phone );
+            update_user_meta( $user_id, 'phone', $phone );
+        }
+
+        do_action( 'sp_booking_updated', $booking_id );
+
+        wp_send_json_success( [ 'message' => __( 'Booking updated successfully.', 'sovereign-parking' ) ] );
+    }
+}

--- a/sovereign-parking/includes/class-sp-booking-cpt.php
+++ b/sovereign-parking/includes/class-sp-booking-cpt.php
@@ -1,0 +1,444 @@
+<?php
+/**
+ * Booking custom post type.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Booking_CPT extends SP_Service {
+
+    const POST_TYPE = 'sp_booking';
+
+    /**
+     * Register hooks.
+     */
+    public function register_hooks() {
+        add_action( 'init', [ $this, 'register_post_type' ] );
+        add_action( 'init', [ $this, 'register_meta' ] );
+        add_filter( 'manage_' . self::POST_TYPE . '_posts_columns', [ $this, 'columns' ] );
+        add_action( 'manage_' . self::POST_TYPE . '_posts_custom_column', [ $this, 'render_column' ], 10, 2 );
+        add_filter( 'manage_edit-' . self::POST_TYPE . '_sortable_columns', [ $this, 'sortable_columns' ] );
+        add_action( 'pre_get_posts', [ $this, 'sort_columns' ] );
+        add_action( 'add_meta_boxes', [ $this, 'add_meta_boxes' ] );
+        add_action( 'save_post_' . self::POST_TYPE, [ $this, 'save_meta' ], 10, 2 );
+        add_filter( 'display_post_states', [ $this, 'post_states' ], 10, 2 );
+        add_filter( 'post_type_link', [ $this, 'prevent_frontend_link' ], 10, 2 );
+    }
+
+    /**
+     * Register post type.
+     */
+    public function register_post_type() {
+        $labels = [
+            'name'               => __( 'Bookings', 'sovereign-parking' ),
+            'singular_name'      => __( 'Booking', 'sovereign-parking' ),
+            'add_new'            => __( 'Add Booking', 'sovereign-parking' ),
+            'add_new_item'       => __( 'Add New Booking', 'sovereign-parking' ),
+            'edit_item'          => __( 'Edit Booking', 'sovereign-parking' ),
+            'new_item'           => __( 'New Booking', 'sovereign-parking' ),
+            'view_item'          => __( 'View Booking', 'sovereign-parking' ),
+            'search_items'       => __( 'Search Bookings', 'sovereign-parking' ),
+            'not_found'          => __( 'No bookings found', 'sovereign-parking' ),
+            'not_found_in_trash' => __( 'No bookings found in Trash', 'sovereign-parking' ),
+        ];
+
+        $args = [
+            'labels'             => $labels,
+            'public'             => false,
+            'show_ui'            => true,
+            'show_in_menu'       => false,
+            'supports'           => [ 'title', 'editor' ],
+            'capability_type'    => [ 'sp_booking', 'sp_bookings' ],
+            'map_meta_cap'       => true,
+        ];
+
+        register_post_type( self::POST_TYPE, $args );
+
+        $statuses = [
+            'sp-pending'     => __( 'Pending Payment', 'sovereign-parking' ),
+            'sp-confirmed'   => __( 'Confirmed', 'sovereign-parking' ),
+            'sp-cancelled'   => __( 'Cancelled', 'sovereign-parking' ),
+            'sp-poa-pending' => __( 'POA – Pending', 'sovereign-parking' ),
+            'sp-poa-paid'    => __( 'POA – Paid', 'sovereign-parking' ),
+        ];
+
+        foreach ( $statuses as $status => $label ) {
+            register_post_status(
+                $status,
+                [
+                    'label'                     => $label,
+                    'public'                    => false,
+                    'internal'                  => true,
+                    'show_in_admin_all_list'    => true,
+                    'show_in_admin_status_list' => true,
+                    'label_count'               => _n_noop( $label . ' <span class="count">(%s)</span>', $label . ' <span class="count">(%s)</span>', 'sovereign-parking' ),
+                ]
+            );
+        }
+    }
+
+    /**
+     * Register booking meta.
+     */
+    public function register_meta() {
+        $meta_fields = [
+            '_sp_booking_number'      => 'string',
+            '_sp_booking_user_id'     => 'integer',
+            '_sp_booking_cruise_id'   => 'integer',
+            '_sp_booking_entry'       => 'string',
+            '_sp_booking_exit'        => 'string',
+            '_sp_booking_days'        => 'integer',
+            '_sp_booking_passengers'  => 'integer',
+            '_sp_booking_shuttle_id'  => 'integer',
+            '_sp_booking_shuttle_date'=> 'string',
+            '_sp_booking_amount'      => 'number',
+            '_sp_booking_payment'     => 'string',
+            '_sp_booking_payment_status' => 'string',
+            '_sp_booking_hold_amount' => 'number',
+            '_sp_booking_vehicle'     => 'string',
+            '_sp_booking_phone'       => 'string',
+            '_sp_booking_email'       => 'string',
+            '_sp_booking_credit_used' => 'number',
+            '_sp_booking_notes'       => 'string',
+        ];
+
+        foreach ( $meta_fields as $key => $type ) {
+            register_post_meta(
+                self::POST_TYPE,
+                $key,
+                [
+                    'type'         => $type,
+                    'single'       => true,
+                    'show_in_rest' => true,
+                    'auth_callback'=> '__return_true',
+                ]
+            );
+        }
+    }
+
+    /**
+     * Add meta boxes for booking details.
+     */
+    public function add_meta_boxes() {
+        add_meta_box( 'sp_booking_details', __( 'Booking Details', 'sovereign-parking' ), [ $this, 'render_meta_box' ], self::POST_TYPE, 'normal', 'high' );
+        add_meta_box( 'sp_booking_customer', __( 'Customer Details', 'sovereign-parking' ), [ $this, 'render_customer_meta_box' ], self::POST_TYPE, 'side', 'default' );
+    }
+
+    /**
+     * Render booking meta box.
+     */
+    public function render_meta_box( $post ) {
+        wp_nonce_field( 'sp_save_booking', 'sp_booking_nonce' );
+
+        $cruise_id  = get_post_meta( $post->ID, '_sp_booking_cruise_id', true );
+        $entry      = get_post_meta( $post->ID, '_sp_booking_entry', true );
+        $exit       = get_post_meta( $post->ID, '_sp_booking_exit', true );
+        $days       = get_post_meta( $post->ID, '_sp_booking_days', true );
+        $passengers = get_post_meta( $post->ID, '_sp_booking_passengers', true );
+        $shuttle_id = get_post_meta( $post->ID, '_sp_booking_shuttle_id', true );
+        $shuttle_date = get_post_meta( $post->ID, '_sp_booking_shuttle_date', true );
+        $amount     = get_post_meta( $post->ID, '_sp_booking_amount', true );
+        $payment    = get_post_meta( $post->ID, '_sp_booking_payment', true );
+        $status     = get_post_meta( $post->ID, '_sp_booking_payment_status', true );
+        $credit     = get_post_meta( $post->ID, '_sp_booking_credit_used', true );
+
+        $cruises = get_posts(
+            [
+                'post_type'      => SP_Cruise_CPT::POST_TYPE,
+                'posts_per_page' => -1,
+                'post_status'    => 'publish',
+                'orderby'        => 'title',
+                'order'          => 'ASC',
+            ]
+        );
+
+        $slots = get_posts(
+            [
+                'post_type'      => SP_Shuttle_Slot_CPT::POST_TYPE,
+                'posts_per_page' => -1,
+                'post_status'    => 'publish',
+                'orderby'        => 'meta_value',
+                'meta_key'       => '_sp_slot_start',
+                'order'          => 'ASC',
+            ]
+        );
+        ?>
+        <p>
+            <label for="sp_booking_cruise"><strong><?php esc_html_e( 'Cruise', 'sovereign-parking' ); ?></strong></label><br />
+            <select name="sp_booking_cruise" id="sp_booking_cruise" class="widefat">
+                <option value="">—</option>
+                <?php foreach ( $cruises as $cruise ) : ?>
+                    <option value="<?php echo esc_attr( $cruise->ID ); ?>" <?php selected( $cruise_id, $cruise->ID ); ?>><?php echo esc_html( $cruise->post_title ); ?></option>
+                <?php endforeach; ?>
+            </select>
+        </p>
+        <p>
+            <label for="sp_booking_entry"><strong><?php esc_html_e( 'Entry Date & Time', 'sovereign-parking' ); ?></strong></label><br />
+            <input type="datetime-local" name="sp_booking_entry" id="sp_booking_entry" class="widefat" value="<?php echo esc_attr( $this->format_local_datetime( $entry ) ); ?>" />
+        </p>
+        <p>
+            <label for="sp_booking_exit"><strong><?php esc_html_e( 'Exit Date & Time', 'sovereign-parking' ); ?></strong></label><br />
+            <input type="datetime-local" name="sp_booking_exit" id="sp_booking_exit" class="widefat" value="<?php echo esc_attr( $this->format_local_datetime( $exit ) ); ?>" />
+        </p>
+        <p>
+            <label for="sp_booking_passengers"><strong><?php esc_html_e( 'Passengers', 'sovereign-parking' ); ?></strong></label><br />
+            <input type="number" min="1" name="sp_booking_passengers" id="sp_booking_passengers" class="small-text" value="<?php echo esc_attr( $passengers ?: 1 ); ?>" />
+        </p>
+        <p>
+            <label for="sp_booking_shuttle"><strong><?php esc_html_e( 'Shuttle Slot', 'sovereign-parking' ); ?></strong></label><br />
+            <select name="sp_booking_shuttle" id="sp_booking_shuttle" class="widefat">
+                <option value="">—</option>
+                <?php foreach ( $slots as $slot ) :
+                    $start = get_post_meta( $slot->ID, '_sp_slot_start', true );
+                    $end   = get_post_meta( $slot->ID, '_sp_slot_end', true );
+                    ?>
+                    <option value="<?php echo esc_attr( $slot->ID ); ?>" <?php selected( $shuttle_id, $slot->ID ); ?>><?php echo esc_html( $slot->post_title ?: ( $start . ' – ' . $end ) ); ?></option>
+                <?php endforeach; ?>
+            </select>
+        </p>
+        <p>
+            <label for="sp_booking_shuttle_date"><strong><?php esc_html_e( 'Shuttle Date', 'sovereign-parking' ); ?></strong></label><br />
+            <input type="date" name="sp_booking_shuttle_date" id="sp_booking_shuttle_date" class="widefat" value="<?php echo esc_attr( $shuttle_date ? gmdate( 'Y-m-d', strtotime( $shuttle_date ) ) : '' ); ?>" />
+        </p>
+        <p>
+            <label for="sp_booking_amount"><strong><?php esc_html_e( 'Amount', 'sovereign-parking' ); ?></strong></label><br />
+            <input type="number" step="0.01" name="sp_booking_amount" id="sp_booking_amount" class="small-text" value="<?php echo esc_attr( $amount ); ?>" />
+        </p>
+        <p>
+            <label for="sp_booking_payment"><strong><?php esc_html_e( 'Payment Method', 'sovereign-parking' ); ?></strong></label><br />
+            <select name="sp_booking_payment" id="sp_booking_payment" class="widefat">
+                <option value="stripe" <?php selected( $payment, 'stripe' ); ?>><?php esc_html_e( 'Stripe', 'sovereign-parking' ); ?></option>
+                <option value="paypal" <?php selected( $payment, 'paypal' ); ?>><?php esc_html_e( 'PayPal', 'sovereign-parking' ); ?></option>
+                <option value="poa" <?php selected( $payment, 'poa' ); ?>><?php esc_html_e( 'Pay on Arrival', 'sovereign-parking' ); ?></option>
+            </select>
+        </p>
+        <p>
+            <label for="sp_booking_payment_status"><strong><?php esc_html_e( 'Payment Status', 'sovereign-parking' ); ?></strong></label><br />
+            <select name="sp_booking_payment_status" id="sp_booking_payment_status" class="widefat">
+                <option value="pending" <?php selected( $status, 'pending' ); ?>><?php esc_html_e( 'Pending', 'sovereign-parking' ); ?></option>
+                <option value="paid" <?php selected( $status, 'paid' ); ?>><?php esc_html_e( 'Paid', 'sovereign-parking' ); ?></option>
+                <option value="poa_pending" <?php selected( $status, 'poa_pending' ); ?>><?php esc_html_e( 'POA – Pending', 'sovereign-parking' ); ?></option>
+                <option value="poa_paid" <?php selected( $status, 'poa_paid' ); ?>><?php esc_html_e( 'POA – Paid', 'sovereign-parking' ); ?></option>
+                <option value="refunded" <?php selected( $status, 'refunded' ); ?>><?php esc_html_e( 'Refunded', 'sovereign-parking' ); ?></option>
+            </select>
+        </p>
+        <p>
+            <label for="sp_booking_credit_used"><strong><?php esc_html_e( 'Credit Applied', 'sovereign-parking' ); ?></strong></label><br />
+            <input type="number" step="0.01" name="sp_booking_credit_used" id="sp_booking_credit_used" class="small-text" value="<?php echo esc_attr( $credit ); ?>" />
+        </p>
+        <?php
+    }
+
+    /**
+     * Render customer meta box.
+     */
+    public function render_customer_meta_box( $post ) {
+        $vehicle = get_post_meta( $post->ID, '_sp_booking_vehicle', true );
+        $phone   = get_post_meta( $post->ID, '_sp_booking_phone', true );
+        $email   = get_post_meta( $post->ID, '_sp_booking_email', true );
+        ?>
+        <p><strong><?php esc_html_e( 'Vehicle Plate', 'sovereign-parking' ); ?></strong><br />
+            <input type="text" name="sp_booking_vehicle" class="widefat" value="<?php echo esc_attr( $vehicle ); ?>" />
+        </p>
+        <p><strong><?php esc_html_e( 'Phone', 'sovereign-parking' ); ?></strong><br />
+            <input type="text" name="sp_booking_phone" class="widefat" value="<?php echo esc_attr( $phone ); ?>" />
+        </p>
+        <p><strong><?php esc_html_e( 'Email', 'sovereign-parking' ); ?></strong><br />
+            <input type="email" name="sp_booking_email" class="widefat" value="<?php echo esc_attr( $email ); ?>" />
+        </p>
+        <?php
+    }
+
+    /**
+     * Save booking meta.
+     */
+    public function save_meta( $post_id, $post ) {
+        if ( ! isset( $_POST['sp_booking_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['sp_booking_nonce'] ) ), 'sp_save_booking' ) ) {
+            return;
+        }
+
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+
+        if ( self::POST_TYPE !== $post->post_type ) {
+            return;
+        }
+
+        $entry     = isset( $_POST['sp_booking_entry'] ) ? SP_Helpers::sanitize_datetime( wp_unslash( $_POST['sp_booking_entry'] ) ) : '';
+        $exit      = isset( $_POST['sp_booking_exit'] ) ? SP_Helpers::sanitize_datetime( wp_unslash( $_POST['sp_booking_exit'] ) ) : '';
+        $days      = SP_Helpers::calculate_days( $entry, $exit );
+        $passengers= isset( $_POST['sp_booking_passengers'] ) ? intval( $_POST['sp_booking_passengers'] ) : 1;
+        $shuttle   = isset( $_POST['sp_booking_shuttle'] ) ? intval( $_POST['sp_booking_shuttle'] ) : 0;
+        $shuttle_date = isset( $_POST['sp_booking_shuttle_date'] ) ? sanitize_text_field( wp_unslash( $_POST['sp_booking_shuttle_date'] ) ) : '';
+        $amount    = isset( $_POST['sp_booking_amount'] ) ? floatval( $_POST['sp_booking_amount'] ) : 0;
+        $payment   = isset( $_POST['sp_booking_payment'] ) ? sanitize_text_field( wp_unslash( $_POST['sp_booking_payment'] ) ) : 'stripe';
+        $status    = isset( $_POST['sp_booking_payment_status'] ) ? sanitize_text_field( wp_unslash( $_POST['sp_booking_payment_status'] ) ) : 'pending';
+        $credit    = isset( $_POST['sp_booking_credit_used'] ) ? floatval( $_POST['sp_booking_credit_used'] ) : 0;
+        $vehicle   = isset( $_POST['sp_booking_vehicle'] ) ? sanitize_text_field( wp_unslash( $_POST['sp_booking_vehicle'] ) ) : '';
+        $phone     = isset( $_POST['sp_booking_phone'] ) ? sanitize_text_field( wp_unslash( $_POST['sp_booking_phone'] ) ) : '';
+        $email     = isset( $_POST['sp_booking_email'] ) ? sanitize_email( wp_unslash( $_POST['sp_booking_email'] ) ) : '';
+        $cruise_id = isset( $_POST['sp_booking_cruise'] ) ? intval( $_POST['sp_booking_cruise'] ) : 0;
+
+        update_post_meta( $post_id, '_sp_booking_cruise_id', $cruise_id );
+        update_post_meta( $post_id, '_sp_booking_entry', $entry );
+        update_post_meta( $post_id, '_sp_booking_exit', $exit );
+        update_post_meta( $post_id, '_sp_booking_days', $days );
+        update_post_meta( $post_id, '_sp_booking_passengers', $passengers );
+        update_post_meta( $post_id, '_sp_booking_shuttle_id', $shuttle );
+        update_post_meta( $post_id, '_sp_booking_shuttle_date', $shuttle_date );
+        update_post_meta( $post_id, '_sp_booking_amount', $amount );
+        update_post_meta( $post_id, '_sp_booking_payment', $payment );
+        update_post_meta( $post_id, '_sp_booking_payment_status', $status );
+        update_post_meta( $post_id, '_sp_booking_credit_used', $credit );
+        update_post_meta( $post_id, '_sp_booking_vehicle', $vehicle );
+        update_post_meta( $post_id, '_sp_booking_phone', $phone );
+        update_post_meta( $post_id, '_sp_booking_email', $email );
+
+        if ( 'poa_pending' === $status ) {
+            wp_update_post(
+                [
+                    'ID'          => $post_id,
+                    'post_status' => 'sp-poa-pending',
+                ]
+            );
+        } elseif ( 'poa_paid' === $status ) {
+            wp_update_post(
+                [
+                    'ID'          => $post_id,
+                    'post_status' => 'sp-poa-paid',
+                ]
+            );
+        } elseif ( 'paid' === $status ) {
+            wp_update_post(
+                [
+                    'ID'          => $post_id,
+                    'post_status' => 'sp-confirmed',
+                ]
+            );
+        } else {
+            wp_update_post(
+                [
+                    'ID'          => $post_id,
+                    'post_status' => 'sp-pending',
+                ]
+            );
+        }
+    }
+
+    /**
+     * Format for datetime-local.
+     */
+    protected function format_local_datetime( $value ) {
+        if ( empty( $value ) ) {
+            return '';
+        }
+
+        $timestamp = strtotime( $value );
+        if ( ! $timestamp ) {
+            return '';
+        }
+
+        return gmdate( 'Y-m-d\TH:i', $timestamp );
+    }
+
+    /**
+     * Admin columns.
+     */
+    public function columns( $columns ) {
+        $columns['sp_booking_number'] = __( 'Booking #', 'sovereign-parking' );
+        $columns['sp_booking_cruise'] = __( 'Cruise', 'sovereign-parking' );
+        $columns['sp_booking_dates']  = __( 'Dates', 'sovereign-parking' );
+        $columns['sp_booking_pass']   = __( 'Passengers', 'sovereign-parking' );
+        $columns['sp_booking_payment']= __( 'Payment', 'sovereign-parking' );
+        return $columns;
+    }
+
+    /**
+     * Render column content.
+     */
+    public function render_column( $column, $post_id ) {
+        switch ( $column ) {
+            case 'sp_booking_number':
+                echo esc_html( get_post_meta( $post_id, '_sp_booking_number', true ) );
+                break;
+            case 'sp_booking_cruise':
+                $cruise_id = get_post_meta( $post_id, '_sp_booking_cruise_id', true );
+                if ( $cruise_id ) {
+                    $cruise = get_post( $cruise_id );
+                    echo esc_html( $cruise ? $cruise->post_title : '' );
+                }
+                break;
+            case 'sp_booking_dates':
+                $entry = get_post_meta( $post_id, '_sp_booking_entry', true );
+                $exit  = get_post_meta( $post_id, '_sp_booking_exit', true );
+                if ( $entry && $exit ) {
+                    echo esc_html( get_date_from_gmt( $entry, get_option( 'date_format' ) ) . ' → ' . get_date_from_gmt( $exit, get_option( 'date_format' ) ) );
+                }
+                break;
+            case 'sp_booking_pass':
+                echo esc_html( get_post_meta( $post_id, '_sp_booking_passengers', true ) );
+                break;
+            case 'sp_booking_payment':
+                $method = get_post_meta( $post_id, '_sp_booking_payment', true );
+                $status = get_post_meta( $post_id, '_sp_booking_payment_status', true );
+                echo esc_html( ucfirst( $method ) . ' / ' . $status );
+                break;
+        }
+    }
+
+    /**
+     * Sortable columns.
+     */
+    public function sortable_columns( $columns ) {
+        $columns['sp_booking_dates'] = 'sp_booking_dates';
+        return $columns;
+    }
+
+    /**
+     * Apply ordering for custom columns.
+     */
+    public function sort_columns( $query ) {
+        if ( ! is_admin() || ! $query->is_main_query() ) {
+            return;
+        }
+
+        if ( self::POST_TYPE !== $query->get( 'post_type' ) ) {
+            return;
+        }
+
+        if ( 'sp_booking_dates' === $query->get( 'orderby' ) ) {
+            $query->set( 'meta_key', '_sp_booking_entry' );
+            $query->set( 'orderby', 'meta_value' );
+        }
+    }
+
+    /**
+     * Show custom state labels.
+     */
+    public function post_states( $states, $post ) {
+        if ( self::POST_TYPE !== $post->post_type ) {
+            return $states;
+        }
+
+        $payment_status = get_post_meta( $post->ID, '_sp_booking_payment_status', true );
+        if ( $payment_status ) {
+            $states[] = sprintf( __( 'Payment: %s', 'sovereign-parking' ), ucfirst( str_replace( '_', ' ', $payment_status ) ) );
+        }
+
+        return $states;
+    }
+
+    /**
+     * Prevent view link from exposing front-end.
+     */
+    public function prevent_frontend_link( $link, $post ) {
+        if ( self::POST_TYPE === $post->post_type ) {
+            return admin_url( 'post.php?post=' . $post->ID . '&action=edit' );
+        }
+
+        return $link;
+    }
+}

--- a/sovereign-parking/includes/class-sp-cruise-cpt.php
+++ b/sovereign-parking/includes/class-sp-cruise-cpt.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Cruise custom post type.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Cruise_CPT extends SP_Service {
+
+    const POST_TYPE = 'sp_cruise';
+
+    /**
+     * Register hooks.
+     */
+    public function register_hooks() {
+        add_action( 'init', [ $this, 'register_cpt' ] );
+        add_action( 'init', [ $this, 'register_meta' ] );
+        add_action( 'add_meta_boxes', [ $this, 'add_meta_boxes' ] );
+        add_action( 'save_post_' . self::POST_TYPE, [ $this, 'save_meta' ], 10, 2 );
+        add_filter( 'manage_' . self::POST_TYPE . '_posts_columns', [ $this, 'columns' ] );
+        add_action( 'manage_' . self::POST_TYPE . '_posts_custom_column', [ $this, 'render_column' ], 10, 2 );
+        add_filter( 'post_updated_messages', [ $this, 'updated_messages' ] );
+    }
+
+    /**
+     * Register cruise post type.
+     */
+    public function register_cpt() {
+        $labels = [
+            'name'               => __( 'Cruises', 'sovereign-parking' ),
+            'singular_name'      => __( 'Cruise', 'sovereign-parking' ),
+            'add_new'            => __( 'Add Cruise', 'sovereign-parking' ),
+            'add_new_item'       => __( 'Add New Cruise', 'sovereign-parking' ),
+            'edit_item'          => __( 'Edit Cruise', 'sovereign-parking' ),
+            'new_item'           => __( 'New Cruise', 'sovereign-parking' ),
+            'view_item'          => __( 'View Cruise', 'sovereign-parking' ),
+            'search_items'       => __( 'Search Cruises', 'sovereign-parking' ),
+            'not_found'          => __( 'No cruises found', 'sovereign-parking' ),
+            'not_found_in_trash' => __( 'No cruises found in Trash', 'sovereign-parking' ),
+        ];
+
+        $args = [
+            'labels'             => $labels,
+            'public'             => false,
+            'show_ui'            => true,
+            'show_in_menu'       => false,
+            'supports'           => [ 'title' ],
+            'capability_type'    => [ 'sp_cruise', 'sp_cruises' ],
+            'map_meta_cap'       => true,
+        ];
+
+        register_post_type( self::POST_TYPE, $args );
+    }
+
+    /**
+     * Register meta fields for cruises.
+     */
+    public function register_meta() {
+        $meta_args = [
+            'type'         => 'string',
+            'single'       => true,
+            'show_in_rest' => true,
+            'auth_callback'=> '__return_true',
+        ];
+
+        register_post_meta( self::POST_TYPE, '_sp_cruise_line', $meta_args );
+        register_post_meta( self::POST_TYPE, '_sp_departure_datetime', $meta_args );
+        register_post_meta( self::POST_TYPE, '_sp_return_datetime', $meta_args );
+        register_post_meta( self::POST_TYPE, '_sp_ship_name', $meta_args );
+    }
+
+    /**
+     * Add meta boxes.
+     */
+    public function add_meta_boxes() {
+        add_meta_box( 'sp_cruise_details', __( 'Cruise Details', 'sovereign-parking' ), [ $this, 'render_meta_box' ], self::POST_TYPE, 'normal', 'high' );
+    }
+
+    /**
+     * Render cruise details meta box.
+     */
+    public function render_meta_box( $post ) {
+        wp_nonce_field( 'sp_save_cruise', 'sp_cruise_nonce' );
+
+        $cruise_line = get_post_meta( $post->ID, '_sp_cruise_line', true );
+        $ship_name   = get_post_meta( $post->ID, '_sp_ship_name', true );
+        $departure   = get_post_meta( $post->ID, '_sp_departure_datetime', true );
+        $return      = get_post_meta( $post->ID, '_sp_return_datetime', true );
+        ?>
+        <p>
+            <label for="sp_cruise_line"><strong><?php esc_html_e( 'Cruise Line', 'sovereign-parking' ); ?></strong></label><br />
+            <input type="text" class="regular-text" name="sp_cruise_line" id="sp_cruise_line" value="<?php echo esc_attr( $cruise_line ); ?>" />
+        </p>
+        <p>
+            <label for="sp_ship_name"><strong><?php esc_html_e( 'Ship Name', 'sovereign-parking' ); ?></strong></label><br />
+            <input type="text" class="regular-text" name="sp_ship_name" id="sp_ship_name" value="<?php echo esc_attr( $ship_name ); ?>" />
+        </p>
+        <p>
+            <label for="sp_departure"><strong><?php esc_html_e( 'Departure Date & Time', 'sovereign-parking' ); ?></strong></label><br />
+            <input type="datetime-local" class="regular-text" name="sp_departure" id="sp_departure" value="<?php echo esc_attr( $this->format_local_datetime( $departure ) ); ?>" />
+        </p>
+        <p>
+            <label for="sp_return"><strong><?php esc_html_e( 'Return Date & Time', 'sovereign-parking' ); ?></strong></label><br />
+            <input type="datetime-local" class="regular-text" name="sp_return" id="sp_return" value="<?php echo esc_attr( $this->format_local_datetime( $return ) ); ?>" />
+        </p>
+        <?php
+    }
+
+    /**
+     * Save cruise details.
+     */
+    public function save_meta( $post_id, $post ) {
+        if ( ! isset( $_POST['sp_cruise_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['sp_cruise_nonce'] ) ), 'sp_save_cruise' ) ) {
+            return;
+        }
+
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+
+        if ( self::POST_TYPE !== $post->post_type ) {
+            return;
+        }
+
+        $cruise_line = isset( $_POST['sp_cruise_line'] ) ? sanitize_text_field( wp_unslash( $_POST['sp_cruise_line'] ) ) : '';
+        $ship_name   = isset( $_POST['sp_ship_name'] ) ? sanitize_text_field( wp_unslash( $_POST['sp_ship_name'] ) ) : '';
+        $departure   = isset( $_POST['sp_departure'] ) ? SP_Helpers::sanitize_datetime( wp_unslash( $_POST['sp_departure'] ) ) : '';
+        $return      = isset( $_POST['sp_return'] ) ? SP_Helpers::sanitize_datetime( wp_unslash( $_POST['sp_return'] ) ) : '';
+
+        update_post_meta( $post_id, '_sp_cruise_line', $cruise_line );
+        update_post_meta( $post_id, '_sp_ship_name', $ship_name );
+        if ( $departure ) {
+            update_post_meta( $post_id, '_sp_departure_datetime', $departure );
+        }
+        if ( $return ) {
+            update_post_meta( $post_id, '_sp_return_datetime', $return );
+        }
+    }
+
+    /**
+     * Format GMT datetime for datetime-local input.
+     */
+    protected function format_local_datetime( $value ) {
+        if ( empty( $value ) ) {
+            return '';
+        }
+
+        $timestamp = strtotime( $value );
+        if ( ! $timestamp ) {
+            return '';
+        }
+
+        return gmdate( 'Y-m-d\TH:i', $timestamp );
+    }
+
+    /**
+     * Columns for admin list.
+     */
+    public function columns( $columns ) {
+        $columns['sp_cruise_line'] = __( 'Cruise Line', 'sovereign-parking' );
+        $columns['sp_ship_name']   = __( 'Ship', 'sovereign-parking' );
+        $columns['sp_departure']   = __( 'Departure', 'sovereign-parking' );
+        $columns['sp_return']      = __( 'Return', 'sovereign-parking' );
+        return $columns;
+    }
+
+    /**
+     * Render column values.
+     */
+    public function render_column( $column, $post_id ) {
+        switch ( $column ) {
+            case 'sp_cruise_line':
+                echo esc_html( get_post_meta( $post_id, '_sp_cruise_line', true ) );
+                break;
+            case 'sp_ship_name':
+                echo esc_html( get_post_meta( $post_id, '_sp_ship_name', true ) );
+                break;
+            case 'sp_departure':
+                $departure = get_post_meta( $post_id, '_sp_departure_datetime', true );
+                echo esc_html( $departure ? get_date_from_gmt( $departure, get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) : '—' );
+                break;
+            case 'sp_return':
+                $return = get_post_meta( $post_id, '_sp_return_datetime', true );
+                echo esc_html( $return ? get_date_from_gmt( $return, get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) : '—' );
+                break;
+        }
+    }
+
+    /**
+     * Update messages.
+     */
+    public function updated_messages( $messages ) {
+        $messages[ self::POST_TYPE ] = [
+            0  => '',
+            1  => __( 'Cruise updated.', 'sovereign-parking' ),
+            6  => __( 'Cruise published.', 'sovereign-parking' ),
+            7  => __( 'Cruise saved.', 'sovereign-parking' ),
+        ];
+        return $messages;
+    }
+}

--- a/sovereign-parking/includes/class-sp-customer-credits.php
+++ b/sovereign-parking/includes/class-sp-customer-credits.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Customer credit ledger manager.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Customer_Credits extends SP_Service {
+
+    const TABLE = 'sp_credit_ledger';
+
+    /**
+     * Singleton instance.
+     *
+     * @var SP_Customer_Credits
+     */
+    protected static $instance;
+
+    /**
+     * Retrieve singleton.
+     */
+    public static function instance() {
+        if ( null === static::$instance ) {
+            static::$instance = new static();
+        }
+
+        return static::$instance;
+    }
+
+    /**
+     * Register hooks.
+     */
+    public function register_hooks() {
+        add_action( 'init', [ $this, 'process_form' ] );
+    }
+
+    /**
+     * Activation - create table.
+     */
+    public function activate() {
+        global $wpdb;
+        $table   = $wpdb->prefix . self::TABLE;
+        $charset = $wpdb->get_charset_collate();
+        $sql     = "CREATE TABLE {$table} (
+            id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+            user_id BIGINT(20) UNSIGNED NOT NULL,
+            booking_id BIGINT(20) UNSIGNED DEFAULT NULL,
+            amount DECIMAL(10,2) NOT NULL DEFAULT 0,
+            description TEXT NULL,
+            created_at DATETIME NOT NULL,
+            PRIMARY KEY (id),
+            KEY user_id (user_id)
+        ) {$charset};";
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta( $sql );
+    }
+
+    /**
+     * Process credit adjustments from admin.
+     */
+    public function process_form() {
+        if ( ! is_admin() || ! isset( $_POST['sp_credit_action'] ) ) {
+            return;
+        }
+
+        if ( ! current_user_can( 'edit_sp_bookings' ) ) {
+            return;
+        }
+
+        if ( ! isset( $_POST['sp_add_credit_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['sp_add_credit_nonce'] ) ), 'sp_add_credit' ) ) {
+            return;
+        }
+
+        $user_id     = isset( $_POST['sp_credit_customer'] ) ? intval( $_POST['sp_credit_customer'] ) : 0;
+        $amount      = isset( $_POST['sp_credit_amount'] ) ? floatval( $_POST['sp_credit_amount'] ) : 0;
+        $description = isset( $_POST['sp_credit_description'] ) ? sanitize_text_field( wp_unslash( $_POST['sp_credit_description'] ) ) : '';
+
+        if ( ! $user_id || 0 === $amount ) {
+            return;
+        }
+
+        $this->add_credit( $user_id, $amount, $description );
+        wp_safe_redirect( add_query_arg( [ 'page' => 'sp-credits', 'updated' => 'true' ], admin_url( 'admin.php' ) ) );
+        exit;
+    }
+
+    /**
+     * Add credit entry and update user balance.
+     */
+    public function add_credit( $user_id, $amount, $description = '', $booking_id = null ) {
+        global $wpdb;
+        $table = $wpdb->prefix . self::TABLE;
+
+        $wpdb->insert(
+            $table,
+            [
+                'user_id'    => $user_id,
+                'booking_id' => $booking_id,
+                'amount'     => $amount,
+                'description'=> $description,
+                'created_at' => current_time( 'mysql', true ),
+            ],
+            [ '%d', '%d', '%f', '%s', '%s' ]
+        );
+
+        $balance = $this->get_balance( $user_id ) + $amount;
+        update_user_meta( $user_id, '_sp_credit_balance', $balance );
+    }
+
+    /**
+     * Deduct credit when used.
+     */
+    public function deduct_credit( $user_id, $amount, $booking_id = null ) {
+        $this->add_credit( $user_id, -abs( $amount ), __( 'Applied to booking', 'sovereign-parking' ), $booking_id );
+    }
+
+    /**
+     * Get balance for user.
+     */
+    public function get_balance( $user_id ) {
+        $balance = get_user_meta( $user_id, '_sp_credit_balance', true );
+        return $balance ? floatval( $balance ) : 0.0;
+    }
+
+    /**
+     * Recent ledger entries.
+     */
+    public function get_recent_ledger( $limit = 20 ) {
+        global $wpdb;
+        $table = $wpdb->prefix . self::TABLE;
+        return $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} ORDER BY created_at DESC LIMIT %d", $limit ) );
+    }
+}

--- a/sovereign-parking/includes/class-sp-customer-portal.php
+++ b/sovereign-parking/includes/class-sp-customer-portal.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Customer self-service portal.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Customer_Portal extends SP_Service {
+
+    /**
+     * Register hooks.
+     */
+    public function register_hooks() {
+        add_shortcode( 'sovereign_parking_portal', [ $this, 'render_portal' ] );
+        add_action( 'wp_enqueue_scripts', [ $this, 'register_assets' ] );
+    }
+
+    /**
+     * Register portal assets.
+     */
+    public function register_assets() {
+        wp_register_style( 'sp-portal', SP_PLUGIN_URL . 'assets/css/portal.css', [], SP_PLUGIN_VERSION );
+        wp_register_script( 'sp-portal', SP_PLUGIN_URL . 'assets/js/portal.js', [ 'jquery' ], SP_PLUGIN_VERSION, true );
+    }
+
+    /**
+     * Render portal content.
+     */
+    public function render_portal() {
+        if ( ! is_user_logged_in() ) {
+            ob_start();
+            echo '<div class="sp-portal-login">';
+            echo '<h2>' . esc_html__( 'Customer Login', 'sovereign-parking' ) . '</h2>';
+            wp_login_form();
+            echo '</div>';
+            return ob_get_clean();
+        }
+
+        wp_enqueue_style( 'sp-portal' );
+        wp_enqueue_script( 'sp-portal' );
+
+        $user_id  = get_current_user_id();
+        $bookings = get_posts(
+            [
+                'post_type'      => SP_Booking_CPT::POST_TYPE,
+                'post_status'    => [ 'sp-confirmed', 'sp-poa-pending', 'sp-poa-paid', 'sp-pending' ],
+                'posts_per_page' => -1,
+                'meta_query'     => [
+                    [
+                        'key'   => '_sp_booking_user_id',
+                        'value' => $user_id,
+                    ],
+                ],
+                'orderby'        => 'meta_value',
+                'meta_key'       => '_sp_booking_entry',
+                'order'          => 'ASC',
+            ]
+        );
+
+        $data = [];
+        foreach ( $bookings as $booking ) {
+            $data[] = [
+                'id'         => $booking->ID,
+                'number'     => get_post_meta( $booking->ID, '_sp_booking_number', true ),
+                'cruise'     => get_the_title( get_post_meta( $booking->ID, '_sp_booking_cruise_id', true ) ),
+                'entry'      => get_post_meta( $booking->ID, '_sp_booking_entry', true ),
+                'exit'       => get_post_meta( $booking->ID, '_sp_booking_exit', true ),
+                'passengers' => (int) get_post_meta( $booking->ID, '_sp_booking_passengers', true ),
+                'shuttle_id' => (int) get_post_meta( $booking->ID, '_sp_booking_shuttle_id', true ),
+                'shuttle_date' => get_post_meta( $booking->ID, '_sp_booking_shuttle_date', true ),
+                'vehicle'    => get_post_meta( $booking->ID, '_sp_booking_vehicle', true ),
+                'phone'      => get_post_meta( $booking->ID, '_sp_booking_phone', true ),
+                'status'     => get_post_meta( $booking->ID, '_sp_booking_payment_status', true ),
+            ];
+        }
+
+        $slots = get_posts(
+            [
+                'post_type'      => SP_Shuttle_Slot_CPT::POST_TYPE,
+                'post_status'    => 'publish',
+                'posts_per_page' => -1,
+                'orderby'        => 'meta_value',
+                'meta_key'       => '_sp_slot_start',
+                'order'          => 'ASC',
+            ]
+        );
+        $slot_data = [];
+        foreach ( $slots as $slot ) {
+            $slot_data[] = [
+                'id'    => $slot->ID,
+                'label' => $slot->post_title,
+            ];
+        }
+
+        wp_localize_script(
+            'sp-portal',
+            'spPortalData',
+            [
+                'nonce'     => wp_create_nonce( 'sp_booking_nonce' ),
+                'bookings'  => $data,
+                'slots'     => $slot_data,
+                'ajaxUrl'   => admin_url( 'admin-ajax.php' ),
+                'strings'   => [
+                    'updateSuccess' => __( 'Booking updated successfully.', 'sovereign-parking' ),
+                    'updateError'   => __( 'Could not update booking. Please try again.', 'sovereign-parking' ),
+                ],
+            ]
+        );
+
+        ob_start();
+        include SP_PLUGIN_DIR . 'templates/frontend/customer-portal.php';
+        return ob_get_clean();
+    }
+}

--- a/sovereign-parking/includes/class-sp-email-manager.php
+++ b/sovereign-parking/includes/class-sp-email-manager.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Email templates and sending logic.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Email_Manager extends SP_Service {
+
+    /**
+     * Register hooks.
+     */
+    public function register_hooks() {
+        add_action( 'sp_booking_payment_confirmed', [ $this, 'send_confirmation' ] );
+    }
+
+    /**
+     * Send confirmation email.
+     */
+    public function send_confirmation( $booking_id ) {
+        $email = get_post_meta( $booking_id, '_sp_booking_email', true );
+        if ( empty( $email ) ) {
+            return;
+        }
+
+        $subject = __( 'Your Sovereign Parking Booking is Confirmed', 'sovereign-parking' );
+        $headers = [];
+        $from    = SP_Helpers::get_option( 'confirmation_email', get_bloginfo( 'admin_email' ) );
+        if ( $from ) {
+            $headers[] = 'From: Sovereign Parking <' . sanitize_email( $from ) . '>';
+            $headers[] = 'Reply-To: Sovereign Parking <hello@sovereignparking.com.au>';
+        }
+
+        $body = $this->build_email_body( $booking_id );
+        wp_mail( $email, $subject, $body, array_merge( $headers, [ 'Content-Type: text/html; charset=UTF-8' ] ) );
+    }
+
+    /**
+     * Build confirmation email body based on spec.
+     */
+    protected function build_email_body( $booking_id ) {
+        $customer_name = get_post_field( 'post_title', $booking_id );
+        $cruise_id     = get_post_meta( $booking_id, '_sp_booking_cruise_id', true );
+        $cruise_name   = $cruise_id ? get_the_title( $cruise_id ) : '';
+        $entry         = get_post_meta( $booking_id, '_sp_booking_entry', true );
+        $exit          = get_post_meta( $booking_id, '_sp_booking_exit', true );
+        $slot_id       = get_post_meta( $booking_id, '_sp_booking_shuttle_id', true );
+        $slot_label    = $slot_id ? get_the_title( $slot_id ) : '';
+        $passengers    = get_post_meta( $booking_id, '_sp_booking_passengers', true );
+        $vehicle       = get_post_meta( $booking_id, '_sp_booking_vehicle', true );
+        $booking_no    = get_post_meta( $booking_id, '_sp_booking_number', true );
+        $entry_human   = $entry ? get_date_from_gmt( $entry, get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) : '';
+        $exit_human    = $exit ? get_date_from_gmt( $exit, get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) : '';
+
+        ob_start();
+        ?>
+        <div style="font-family:Arial, sans-serif; font-size:14px; color:#222;">
+            <p><?php printf( __( 'Dear %s,', 'sovereign-parking' ), esc_html( $customer_name ) ); ?></p>
+            <p><?php esc_html_e( "That’s it! You’ve officially ticked parking off your list – your spot at Sovereign Parking is confirmed and ready for you.", 'sovereign-parking' ); ?></p>
+            <p><?php esc_html_e( 'On cruise day, just head to 9 Harris Rd, Pinkenba. Drive straight into our concreted all-weather drop-off area, where our team will get you sorted quickly and easily. Feel free to relax in our comfy waiting room, grab a tea or coffee, and take five while we handle the rest. Once we are loaded, it’s only a quick 4km trip to the terminal.', 'sovereign-parking' ); ?></p>
+            <p><?php esc_html_e( 'Your car is in good hands so you can put your energy where it matters – starting your holiday calm, stress-free, and on time.', 'sovereign-parking' ); ?></p>
+            <p><?php esc_html_e( 'If you have any questions or need to update your booking, please DO NOT reply to this email. Email hello@sovereignparking.com.au or call or text us on 0468 472 757. We’re here to help.', 'sovereign-parking' ); ?></p>
+            <p><?php esc_html_e( 'See you soon,', 'sovereign-parking' ); ?><br /><?php esc_html_e( 'The Sovereign Parking Team', 'sovereign-parking' ); ?></p>
+            <h3><?php esc_html_e( 'Booking Summary', 'sovereign-parking' ); ?></h3>
+            <ul>
+                <li><strong><?php esc_html_e( 'Booking Number:', 'sovereign-parking' ); ?></strong> <?php echo esc_html( $booking_no ); ?></li>
+                <li><strong><?php esc_html_e( 'Cruise:', 'sovereign-parking' ); ?></strong> <?php echo esc_html( $cruise_name ); ?></li>
+                <li><strong><?php esc_html_e( 'Entry:', 'sovereign-parking' ); ?></strong> <?php echo esc_html( $entry_human ); ?></li>
+                <li><strong><?php esc_html_e( 'Exit:', 'sovereign-parking' ); ?></strong> <?php echo esc_html( $exit_human ); ?></li>
+                <li><strong><?php esc_html_e( 'Shuttle Slot:', 'sovereign-parking' ); ?></strong> <?php echo esc_html( $slot_label ); ?></li>
+                <li><strong><?php esc_html_e( 'Passengers:', 'sovereign-parking' ); ?></strong> <?php echo esc_html( $passengers ); ?></li>
+                <li><strong><?php esc_html_e( 'Vehicle Plate:', 'sovereign-parking' ); ?></strong> <?php echo esc_html( $vehicle ); ?></li>
+            </ul>
+            <hr />
+            <h3><?php esc_html_e( 'Important Information', 'sovereign-parking' ); ?></h3>
+            <p><strong><?php esc_html_e( 'Shuttle Transfers – Courtesy Note', 'sovereign-parking' ); ?></strong><br /><?php esc_html_e( 'During peak times, we kindly suggest dropping passengers and luggage at the cruise terminal before parking. This courtesy step helps free up shuttle capacity, allowing more transfers to run smoothly and making additional time slots available for all guests.', 'sovereign-parking' ); ?></p>
+            <p><strong><?php esc_html_e( 'Timing Disclaimer', 'sovereign-parking' ); ?></strong><br /><?php esc_html_e( 'We do our best to get you to the cruise terminal within your selected shuttle time slot. However, we cannot control external factors such as traffic congestion or roadworks. Access to the terminal is via a single road in and out, so while rare, delays may occur.', 'sovereign-parking' ); ?></p>
+            <p><strong><?php esc_html_e( 'Accessibility', 'sovereign-parking' ); ?></strong><br /><?php esc_html_e( 'Currently, our car park does not have accommodations for guests with mobility limitations. If you’re travelling with someone who needs assistance, we recommend dropping them at the cruise terminal before parking.', 'sovereign-parking' ); ?></p>
+            <p><strong><?php esc_html_e( 'Passenger & Luggage Drop-off', 'sovereign-parking' ); ?></strong><br /><?php esc_html_e( 'Where possible, please drop passengers and luggage at the terminal first (see courtesy note above).', 'sovereign-parking' ); ?></p>
+            <p><strong><?php esc_html_e( 'Parking Days & Hours', 'sovereign-parking' ); ?></strong><br /><?php esc_html_e( 'We operate 6:00am–2:00pm and only on days when cruises are scheduled. To check availability, see the Cruise Ship Schedule on our website.', 'sovereign-parking' ); ?></p>
+            <p><strong><?php esc_html_e( 'Keys', 'sovereign-parking' ); ?></strong><br /><?php esc_html_e( 'For insurance and liability purposes, our staff will park your vehicle on your behalf. We’ll collect your keys on arrival to ensure proper handling and security.', 'sovereign-parking' ); ?></p>
+            <p><strong><?php esc_html_e( 'Refund & Cancellations Policy', 'sovereign-parking' ); ?></strong><br /><?php esc_html_e( 'We understand that plans can change, so we encourage you to carefully review your booking details and parking location before confirming.', 'sovereign-parking' ); ?></p>
+            <ul>
+                <li><?php esc_html_e( 'Incorrect Bookings / Wrong Location: Unfortunately, we are unable to provide refunds for bookings made in error or for arriving at the wrong parking location.', 'sovereign-parking' ); ?></li>
+                <li><?php esc_html_e( 'Cancellations Within 48 Hours: As we prepare in advance for your arrival, refunds are not available within 48 hours of your booking start time.', 'sovereign-parking' ); ?></li>
+                <li><?php esc_html_e( 'Stripe Fees & Deposits: For fully paid bookings, any refund will have third-party Stripe processing fees deducted. The $10 holding deposit for Pay on Arrival bookings is non-refundable.', 'sovereign-parking' ); ?></li>
+                <li><?php esc_html_e( 'Credits: Where a refund is not possible, we are happy to issue a credit to your Sovereign Parking account. Credits can be applied to your next booking and never expire.', 'sovereign-parking' ); ?></li>
+            </ul>
+            <p><?php esc_html_e( 'Harris Road is a cul-de-sac, and we are the last business on the left. Look for the pink flags!', 'sovereign-parking' ); ?></p>
+        </div>
+        <?php
+        return ob_get_clean();
+    }
+}

--- a/sovereign-parking/includes/class-sp-frontend-booking.php
+++ b/sovereign-parking/includes/class-sp-frontend-booking.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Front-end booking form and scripts.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Frontend_Booking extends SP_Service {
+
+    /**
+     * Register hooks.
+     */
+    public function register_hooks() {
+        add_shortcode( 'sovereign_parking_booking', [ $this, 'render_booking_form' ] );
+        add_action( 'wp_enqueue_scripts', [ $this, 'register_assets' ] );
+    }
+
+    /**
+     * Register scripts and styles.
+     */
+    public function register_assets() {
+        wp_register_style( 'sp-frontend', SP_PLUGIN_URL . 'assets/css/frontend.css', [], SP_PLUGIN_VERSION );
+        wp_register_script( 'sp-frontend', SP_PLUGIN_URL . 'assets/js/frontend.js', [ 'jquery' ], SP_PLUGIN_VERSION, true );
+    }
+
+    /**
+     * Render booking form shortcode.
+     */
+    public function render_booking_form( $atts ) {
+        wp_enqueue_style( 'sp-frontend' );
+        wp_enqueue_script( 'sp-frontend' );
+
+        $atts = shortcode_atts( [
+            'show_title' => true,
+        ], $atts, 'sovereign_parking_booking' );
+
+        $cruises = get_posts(
+            [
+                'post_type'      => SP_Cruise_CPT::POST_TYPE,
+                'post_status'    => 'publish',
+                'posts_per_page' => -1,
+                'orderby'        => 'meta_value',
+                'meta_key'       => '_sp_departure_datetime',
+                'order'          => 'ASC',
+            ]
+        );
+
+        $shuttle_slots = get_posts(
+            [
+                'post_type'      => SP_Shuttle_Slot_CPT::POST_TYPE,
+                'post_status'    => 'publish',
+                'posts_per_page' => -1,
+                'orderby'        => 'meta_value',
+                'meta_key'       => '_sp_slot_start',
+                'order'          => 'ASC',
+            ]
+        );
+
+        $cruise_data = [];
+        foreach ( $cruises as $cruise ) {
+            $cruise_data[] = [
+                'id'        => $cruise->ID,
+                'title'     => $cruise->post_title,
+                'line'      => get_post_meta( $cruise->ID, '_sp_cruise_line', true ),
+                'ship'      => get_post_meta( $cruise->ID, '_sp_ship_name', true ),
+                'departure' => get_post_meta( $cruise->ID, '_sp_departure_datetime', true ),
+                'return'    => get_post_meta( $cruise->ID, '_sp_return_datetime', true ),
+            ];
+        }
+
+        $slot_data = [];
+        foreach ( $shuttle_slots as $slot ) {
+            $slot_data[] = [
+                'id'       => $slot->ID,
+                'label'    => $slot->post_title,
+                'start'    => get_post_meta( $slot->ID, '_sp_slot_start', true ),
+                'end'      => get_post_meta( $slot->ID, '_sp_slot_end', true ),
+                'capacity' => (int) get_post_meta( $slot->ID, '_sp_slot_capacity', true ),
+            ];
+        }
+
+        $pricing = [
+            [ 'days' => 1, 'price' => 69 ],
+            [ 'days' => 2, 'price' => 89 ],
+            [ 'days' => 3, 'price' => 99 ],
+            [ 'days' => 4, 'price' => 109 ],
+            [ 'days' => 5, 'price' => 119 ],
+            [ 'days' => 6, 'price' => 129 ],
+            [ 'days' => 7, 'price' => 139 ],
+            [ 'days' => 8, 'price' => 149 ],
+            [ 'days' => 9, 'price' => 159 ],
+            [ 'days' => 10, 'price' => 169 ],
+            [ 'days' => 11, 'price' => 179 ],
+            [ 'days' => 12, 'price' => 189 ],
+            [ 'days' => 13, 'price' => 199 ],
+            [ 'days' => 14, 'price' => 209 ],
+            [ 'days' => 15, 'price' => 219 ],
+            [ 'days' => 16, 'price' => 229 ],
+            [ 'days' => 17, 'price' => 239 ],
+            [ 'days' => 18, 'price' => 249 ],
+            [ 'days' => 19, 'price' => 259 ],
+            [ 'days' => 20, 'price' => 269 ],
+            [ 'days' => 21, 'price' => 279 ],
+            [ 'days' => 22, 'price' => 289 ],
+            [ 'days' => 23, 'price' => 299 ],
+            [ 'days' => 24, 'price' => 309 ],
+            [ 'days' => 25, 'price' => 319 ],
+            [ 'days' => 26, 'price' => 329 ],
+            [ 'days' => 27, 'price' => 339 ],
+            [ 'days' => 28, 'price' => 349 ],
+            [ 'days' => 29, 'price' => 359 ],
+            [ 'days' => 30, 'price' => 0 ],
+        ];
+
+        wp_localize_script(
+            'sp-frontend',
+            'spBookingData',
+            [
+                'ajaxUrl'       => admin_url( 'admin-ajax.php' ),
+                'nonce'         => wp_create_nonce( 'sp_booking_nonce' ),
+                'cruises'       => $cruise_data,
+                'slots'         => $slot_data,
+                'pricing'       => $pricing,
+                'strings'       => [
+                    'step'          => __( 'Step', 'sovereign-parking' ),
+                    'courtesyNote'  => __( 'During peak times, we kindly suggest dropping passengers and luggage at the cruise terminal before parking. This courtesy step helps free up shuttle capacity, allowing more transfers to run smoothly and making additional time slots available for all guests.', 'sovereign-parking' ),
+                    'disclaimer'    => __( 'We do our best to get you to the cruise terminal within your selected time slot. However, we cannot control external factors such as traffic congestion or roadworks. Access to the terminal is via a single road in and out, so - while rare - delays may occur.', 'sovereign-parking' ),
+                    'payOnArrival'  => __( 'Pay on Arrival requires a $10 holding deposit. The balance is due on arrival.', 'sovereign-parking' ),
+                    'callForQuote'  => __( 'For stays of 30 days or more, please call for a personalised quote.', 'sovereign-parking' ),
+                    'noSlots'       => __( 'No shuttle slots are available for the selected date. Please adjust passengers or time.', 'sovereign-parking' ),
+                ],
+                'depositAmount' => (float) SP_Helpers::get_option( 'poa_deposit_amount', 10 ),
+            ]
+        );
+
+        ob_start();
+        $confirmation = isset( $_GET['sp_booking_confirmed'] ) ? absint( $_GET['booking'] ) : 0;
+        include SP_PLUGIN_DIR . 'templates/frontend/booking-form.php';
+        return ob_get_clean();
+    }
+}

--- a/sovereign-parking/includes/class-sp-helpers.php
+++ b/sovereign-parking/includes/class-sp-helpers.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Shared helper utilities.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Helpers {
+
+    /**
+     * Calculate price based on number of days.
+     *
+     * @param int $days Number of days.
+     *
+     * @return float
+     */
+    public static function calculate_price( $days ) {
+        $pricing = [
+            1  => 69,
+            2  => 89,
+            3  => 99,
+            4  => 109,
+            5  => 119,
+            6  => 129,
+            7  => 139,
+            8  => 149,
+            9  => 159,
+            10 => 169,
+            11 => 179,
+            12 => 189,
+            13 => 199,
+            14 => 209,
+            15 => 219,
+            16 => 229,
+            17 => 239,
+            18 => 249,
+            19 => 259,
+            20 => 269,
+            21 => 279,
+            22 => 289,
+            23 => 299,
+            24 => 309,
+            25 => 319,
+            26 => 329,
+            27 => 339,
+            28 => 349,
+            29 => 359,
+        ];
+
+        if ( $days >= 30 ) {
+            return 0;
+        }
+
+        if ( isset( $pricing[ $days ] ) ) {
+            return (float) $pricing[ $days ];
+        }
+
+        if ( $days > 20 && $days < 30 ) {
+            return 269;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Sanitize datetime string.
+     *
+     * @param string $value Raw value.
+     *
+     * @return string|null
+     */
+    public static function sanitize_datetime( $value ) {
+        $value = sanitize_text_field( $value );
+
+        if ( empty( $value ) ) {
+            return null;
+        }
+
+        $timestamp = strtotime( $value );
+        if ( false === $timestamp ) {
+            return null;
+        }
+
+        return gmdate( 'Y-m-d H:i:s', $timestamp );
+    }
+
+    /**
+     * Convert two date strings into day count.
+     *
+     * @param string $entry Entry datetime.
+     * @param string $exit  Exit datetime.
+     *
+     * @return int
+     */
+    public static function calculate_days( $entry, $exit ) {
+        $entry_ts = strtotime( $entry );
+        $exit_ts  = strtotime( $exit );
+
+        if ( ! $entry_ts || ! $exit_ts ) {
+            return 0;
+        }
+
+        $diff = $exit_ts - $entry_ts;
+        if ( $diff < 0 ) {
+            return 0;
+        }
+
+        return (int) ceil( $diff / DAY_IN_SECONDS );
+    }
+
+    /**
+     * Retrieve plugin option value.
+     *
+     * @param string $key     Key.
+     * @param mixed  $default Default.
+     *
+     * @return mixed
+     */
+    public static function get_option( $key, $default = '' ) {
+        $options = get_option( 'sp_settings', [] );
+
+        if ( isset( $options[ $key ] ) && '' !== $options[ $key ] ) {
+            return $options[ $key ];
+        }
+
+        return $default;
+    }
+
+    /**
+     * Update plugin option.
+     *
+     * @param string $key   Key.
+     * @param mixed  $value Value.
+     */
+    public static function update_option( $key, $value ) {
+        $options = get_option( 'sp_settings', [] );
+        $options[ $key ] = $value;
+        update_option( 'sp_settings', $options );
+    }
+
+    /**
+     * Format currency.
+     *
+     * @param float $amount Amount.
+     *
+     * @return string
+     */
+    public static function format_currency( $amount ) {
+        return sprintf( '$%s', number_format_i18n( $amount, 2 ) );
+    }
+
+    /**
+     * Generate booking number.
+     *
+     * @return string
+     */
+    public static function generate_booking_number() {
+        return strtoupper( 'SP-' . wp_generate_password( 8, false, false ) );
+    }
+
+    /**
+     * Return default shuttle slots.
+     *
+     * @return array
+     */
+    public static function default_shuttle_slots() {
+        $slots = [
+            [ 'start' => '09:30', 'end' => '09:49' ],
+            [ 'start' => '09:50', 'end' => '10:09' ],
+            [ 'start' => '10:10', 'end' => '10:29' ],
+            [ 'start' => '10:30', 'end' => '10:49' ],
+            [ 'start' => '10:50', 'end' => '11:09' ],
+            [ 'start' => '11:10', 'end' => '11:29' ],
+            [ 'start' => '11:30', 'end' => '11:49' ],
+            [ 'start' => '11:50', 'end' => '12:09' ],
+            [ 'start' => '12:10', 'end' => '12:29' ],
+            [ 'start' => '12:30', 'end' => '12:49' ],
+            [ 'start' => '12:50', 'end' => '13:09' ],
+            [ 'start' => '13:10', 'end' => '13:29' ],
+            [ 'start' => '13:30', 'end' => '13:49' ],
+        ];
+
+        $normalized = [];
+        foreach ( $slots as $slot ) {
+            $key            = str_replace( ':', '', $slot['start'] ) . '-' . str_replace( ':', '', $slot['end'] );
+            $normalized[ $key ] = [
+                'label'    => sprintf( '%s–%s', $slot['start'], $slot['end'] ),
+                'start'    => $slot['start'],
+                'end'      => $slot['end'],
+                'capacity' => 11,
+            ];
+        }
+
+        return $normalized;
+    }
+}

--- a/sovereign-parking/includes/class-sp-payment-paypal.php
+++ b/sovereign-parking/includes/class-sp-payment-paypal.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * PayPal integration.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Payment_Paypal extends SP_Service {
+
+    protected static $instance;
+
+    /**
+     * Get singleton instance.
+     */
+    public static function instance() {
+        if ( null === static::$instance ) {
+            static::$instance = new static();
+        }
+        return static::$instance;
+    }
+
+    /**
+     * Register hooks.
+     */
+    public function register_hooks() {
+        add_filter( 'query_vars', [ $this, 'register_query_vars' ] );
+        add_action( 'template_redirect', [ $this, 'handle_confirmation' ] );
+    }
+
+    /**
+     * Register query vars.
+     */
+    public function register_query_vars( $vars ) {
+        $vars[] = 'sp_paypal_confirm';
+        $vars[] = 'sp_paypal_token';
+        $vars[] = 'sp_booking';
+        return $vars;
+    }
+
+    /**
+     * Create PayPal order and return approval URL.
+     */
+    public function create_order( $booking_id, $amount, $source_url = '' ) {
+        $client_id = SP_Helpers::get_option( 'paypal_client_id' );
+        $secret    = SP_Helpers::get_option( 'paypal_secret' );
+
+        if ( empty( $client_id ) || empty( $secret ) ) {
+            return new WP_Error( 'sp_paypal_keys_missing', __( 'PayPal credentials missing.', 'sovereign-parking' ) );
+        }
+
+        if ( $amount <= 0 ) {
+            return new WP_Error( 'sp_invalid_amount', __( 'Invalid amount.', 'sovereign-parking' ) );
+        }
+
+        $token = $this->get_access_token( $client_id, $secret );
+        if ( is_wp_error( $token ) ) {
+            return $token;
+        }
+
+        $success_url = add_query_arg(
+            [
+                'sp_paypal_confirm' => 1,
+                'sp_booking'        => $booking_id,
+            ],
+            home_url( '/' )
+        );
+        $cancel_url  = $source_url ? $source_url : home_url( '/' );
+
+        $body = [
+            'intent'              => 'CAPTURE',
+            'purchase_units'      => [
+                [
+                    'reference_id' => (string) $booking_id,
+                    'amount'       => [
+                        'currency_code' => 'AUD',
+                        'value'         => number_format( $amount, 2, '.', '' ),
+                    ],
+                ],
+            ],
+            'application_context' => [
+                'return_url' => $success_url,
+                'cancel_url' => $cancel_url,
+            ],
+        ];
+
+        $response = wp_remote_post(
+            'https://api-m.paypal.com/v2/checkout/orders',
+            [
+                'headers' => [
+                    'Content-Type'  => 'application/json',
+                    'Authorization' => 'Bearer ' . $token,
+                ],
+                'body'    => wp_json_encode( $body ),
+                'timeout' => 60,
+            ]
+        );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( empty( $data['id'] ) ) {
+            return new WP_Error( 'sp_paypal_error', __( 'Unable to create PayPal order.', 'sovereign-parking' ) );
+        }
+
+        update_post_meta( $booking_id, '_sp_paypal_order_id', sanitize_text_field( $data['id'] ) );
+        if ( $source_url ) {
+            update_post_meta( $booking_id, '_sp_booking_source_url', esc_url_raw( $source_url ) );
+        }
+
+        foreach ( $data['links'] as $link ) {
+            if ( 'approve' === $link['rel'] ) {
+                return [ 'url' => $link['href'] ];
+            }
+        }
+
+        return new WP_Error( 'sp_paypal_no_approval', __( 'PayPal approval link missing.', 'sovereign-parking' ) );
+    }
+
+    /**
+     * Handle PayPal confirmation.
+     */
+    public function handle_confirmation() {
+        if ( ! get_query_var( 'sp_paypal_confirm' ) ) {
+            return;
+        }
+
+        $booking_id = absint( get_query_var( 'sp_booking' ) );
+        $token      = isset( $_GET['token'] ) ? sanitize_text_field( wp_unslash( $_GET['token'] ) ) : '';
+
+        if ( ! $booking_id || empty( $token ) ) {
+            wp_safe_redirect( home_url( '/' ) );
+            exit;
+        }
+
+        $client_id = SP_Helpers::get_option( 'paypal_client_id' );
+        $secret    = SP_Helpers::get_option( 'paypal_secret' );
+        $access    = $this->get_access_token( $client_id, $secret );
+        if ( is_wp_error( $access ) ) {
+            wp_safe_redirect( home_url( '/' ) );
+            exit;
+        }
+
+        $response = wp_remote_post(
+            'https://api-m.paypal.com/v2/checkout/orders/' . rawurlencode( $token ) . '/capture',
+            [
+                'headers' => [
+                    'Content-Type'  => 'application/json',
+                    'Authorization' => 'Bearer ' . $access,
+                ],
+                'timeout' => 60,
+            ]
+        );
+
+        if ( is_wp_error( $response ) ) {
+            wp_safe_redirect( home_url( '/' ) );
+            exit;
+        }
+
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( empty( $data['status'] ) || 'COMPLETED' !== $data['status'] ) {
+            wp_safe_redirect( home_url( '/' ) );
+            exit;
+        }
+
+        update_post_meta( $booking_id, '_sp_booking_payment_status', 'paid' );
+        update_post_meta( $booking_id, '_sp_booking_payment', 'paypal' );
+        update_post_meta( $booking_id, '_sp_paypal_transaction', sanitize_text_field( $token ) );
+        wp_update_post(
+            [
+                'ID'          => $booking_id,
+                'post_status' => 'sp-confirmed',
+            ]
+        );
+
+        do_action( 'sp_booking_payment_confirmed', $booking_id );
+
+        $redirect = get_post_meta( $booking_id, '_sp_booking_source_url', true );
+        if ( empty( $redirect ) ) {
+            $redirect = home_url( '/' );
+        }
+        wp_safe_redirect( add_query_arg( [ 'sp_booking_confirmed' => 1, 'booking' => $booking_id ], $redirect ) );
+        exit;
+    }
+
+    /**
+     * Retrieve access token from PayPal.
+     */
+    protected function get_access_token( $client_id, $secret ) {
+        $response = wp_remote_post(
+            'https://api-m.paypal.com/v1/oauth2/token',
+            [
+                'headers' => [
+                    'Authorization' => 'Basic ' . base64_encode( $client_id . ':' . $secret ),
+                ],
+                'body'    => [ 'grant_type' => 'client_credentials' ],
+                'timeout' => 60,
+            ]
+        );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( empty( $data['access_token'] ) ) {
+            return new WP_Error( 'sp_paypal_token', __( 'Unable to authenticate with PayPal.', 'sovereign-parking' ) );
+        }
+
+        return $data['access_token'];
+    }
+}

--- a/sovereign-parking/includes/class-sp-payment-stripe.php
+++ b/sovereign-parking/includes/class-sp-payment-stripe.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Stripe payment integration.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Payment_Stripe extends SP_Service {
+
+    /**
+     * Singleton instance.
+     *
+     * @var SP_Payment_Stripe
+     */
+    protected static $instance;
+
+    /**
+     * Retrieve singleton instance.
+     */
+    public static function instance() {
+        if ( null === static::$instance ) {
+            static::$instance = new static();
+        }
+
+        return static::$instance;
+    }
+
+    /**
+     * Register hooks.
+     */
+    public function register_hooks() {
+        add_filter( 'query_vars', [ $this, 'register_query_vars' ] );
+        add_action( 'template_redirect', [ $this, 'handle_confirmation' ] );
+    }
+
+    /**
+     * Add query vars used for confirmation.
+     */
+    public function register_query_vars( $vars ) {
+        $vars[] = 'sp_stripe_confirm';
+        $vars[] = 'sp_stripe_session';
+        $vars[] = 'sp_booking';
+        return $vars;
+    }
+
+    /**
+     * Create checkout session and return checkout URL.
+     */
+    public function create_checkout_session( $booking_id, $amount, $mode = 'full', $source_url = '' ) {
+        $secret = SP_Helpers::get_option( 'stripe_secret' );
+        $publishable = SP_Helpers::get_option( 'stripe_publishable' );
+
+        if ( empty( $secret ) || empty( $publishable ) ) {
+            return new WP_Error( 'sp_stripe_keys_missing', __( 'Stripe keys are not configured.', 'sovereign-parking' ) );
+        }
+
+        if ( $amount <= 0 ) {
+            return new WP_Error( 'sp_invalid_amount', __( 'Invalid amount.', 'sovereign-parking' ) );
+        }
+
+        $line_description = 'Sovereign Parking - ' . ( 'full' === $mode ? __( 'Full Payment', 'sovereign-parking' ) : __( 'POA Deposit', 'sovereign-parking' ) );
+        $success_url      = add_query_arg(
+            [
+                'sp_stripe_confirm' => 1,
+                'sp_booking'        => $booking_id,
+                'sp_stripe_session' => '{CHECKOUT_SESSION_ID}',
+                'mode'              => $mode,
+            ],
+            home_url( '/' )
+        );
+        $cancel_url       = $source_url ? $source_url : home_url( '/' );
+
+        if ( $source_url ) {
+            update_post_meta( $booking_id, '_sp_booking_source_url', esc_url_raw( $source_url ) );
+        }
+
+        $body = [
+            'mode'                              => 'payment',
+            'payment_method_types[]'            => 'card',
+            'success_url'                       => $success_url,
+            'cancel_url'                        => $cancel_url,
+            'line_items[0][price_data][currency]'   => 'aud',
+            'line_items[0][price_data][unit_amount]' => intval( round( $amount * 100 ) ),
+            'line_items[0][price_data][product_data][name]' => $line_description,
+            'line_items[0][quantity]'                 => 1,
+            'metadata[booking_id]'                   => $booking_id,
+            'metadata[payment_mode]'                 => $mode,
+        ];
+
+        $response = wp_remote_post(
+            'https://api.stripe.com/v1/checkout/sessions',
+            [
+                'headers' => [
+                    'Authorization' => 'Basic ' . base64_encode( $secret . ':' ),
+                ],
+                'body'    => $body,
+                'timeout' => 60,
+            ]
+        );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $code = wp_remote_retrieve_response_code( $response );
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( 200 !== $code ) {
+            return new WP_Error( 'sp_stripe_error', isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Stripe error', 'sovereign-parking' ) );
+        }
+
+        if ( isset( $data['id'] ) ) {
+            update_post_meta( $booking_id, '_sp_stripe_session_id', sanitize_text_field( $data['id'] ) );
+            update_post_meta( $booking_id, '_sp_stripe_mode', $mode );
+        }
+
+        return [
+            'url'           => $data['url'],
+            'publishableKey'=> $publishable,
+            'sessionId'     => $data['id'],
+        ];
+    }
+
+    /**
+     * Handle Stripe confirmation redirect.
+     */
+    public function handle_confirmation() {
+        if ( ! get_query_var( 'sp_stripe_confirm' ) ) {
+            return;
+        }
+
+        $booking_id = absint( get_query_var( 'sp_booking' ) );
+        $session_id = sanitize_text_field( get_query_var( 'sp_stripe_session' ) );
+        $mode       = sanitize_text_field( isset( $_GET['mode'] ) ? wp_unslash( $_GET['mode'] ) : 'full' );
+
+        if ( ! $booking_id || empty( $session_id ) ) {
+            wp_safe_redirect( home_url( '/' ) );
+            exit;
+        }
+
+        $secret = SP_Helpers::get_option( 'stripe_secret' );
+        if ( empty( $secret ) ) {
+            wp_safe_redirect( home_url( '/' ) );
+            exit;
+        }
+
+        $response = wp_remote_get(
+            'https://api.stripe.com/v1/checkout/sessions/' . rawurlencode( $session_id ),
+            [
+                'headers' => [
+                    'Authorization' => 'Basic ' . base64_encode( $secret . ':' ),
+                ],
+                'timeout' => 60,
+            ]
+        );
+
+        if ( is_wp_error( $response ) ) {
+            wp_safe_redirect( home_url( '/' ) );
+            exit;
+        }
+
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( empty( $data ) || empty( $data['payment_status'] ) || 'paid' !== $data['payment_status'] ) {
+            $redirect = get_post_meta( $booking_id, '_sp_booking_source_url', true );
+            wp_safe_redirect( $redirect ? $redirect : home_url( '/' ) );
+            exit;
+        }
+
+        $payment_status = get_post_meta( $booking_id, '_sp_booking_payment_status', true );
+        $mode_meta      = get_post_meta( $booking_id, '_sp_stripe_mode', true );
+
+        if ( 'poa' === get_post_meta( $booking_id, '_sp_booking_payment', true ) || 'deposit' === $mode || 'deposit' === $mode_meta ) {
+            update_post_meta( $booking_id, '_sp_booking_payment_status', 'poa_pending' );
+            update_post_meta( $booking_id, '_sp_booking_deposit_status', 'paid' );
+            update_post_meta( $booking_id, '_sp_booking_deposit_transaction', $session_id );
+            wp_update_post(
+                [
+                    'ID'          => $booking_id,
+                    'post_status' => 'sp-poa-pending',
+                ]
+            );
+        } else {
+            update_post_meta( $booking_id, '_sp_booking_payment_status', 'paid' );
+            update_post_meta( $booking_id, '_sp_booking_transaction', $session_id );
+            wp_update_post(
+                [
+                    'ID'          => $booking_id,
+                    'post_status' => 'sp-confirmed',
+                ]
+            );
+        }
+
+        do_action( 'sp_booking_payment_confirmed', $booking_id );
+
+        $redirect = get_post_meta( $booking_id, '_sp_booking_source_url', true );
+        if ( empty( $redirect ) ) {
+            $redirect = home_url( '/' );
+        }
+        wp_safe_redirect( add_query_arg( [ 'sp_booking_confirmed' => 1, 'booking' => $booking_id ], $redirect ) );
+        exit;
+    }
+}

--- a/sovereign-parking/includes/class-sp-plugin.php
+++ b/sovereign-parking/includes/class-sp-plugin.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Main plugin orchestrator.
+ *
+ * @package SovereignParking
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Class SP_Plugin
+ */
+class SP_Plugin {
+
+    /**
+     * Singleton instance.
+     *
+     * @var SP_Plugin
+     */
+    protected static $instance;
+
+    /**
+     * Tracks if plugin has been booted.
+     *
+     * @var bool
+     */
+    protected $booted = false;
+
+    /**
+     * Registered services.
+     *
+     * @var array
+     */
+    protected $services = [];
+
+    /**
+     * Retrieve singleton instance.
+     *
+     * @return SP_Plugin
+     */
+    public static function instance() {
+        if ( null === static::$instance ) {
+            static::$instance = new static();
+        }
+
+        return static::$instance;
+    }
+
+    /**
+     * Boot plugin services.
+     */
+    public function boot() {
+        if ( $this->booted ) {
+            return;
+        }
+
+        load_plugin_textdomain( 'sovereign-parking', false, dirname( plugin_basename( SP_PLUGIN_FILE ) ) . '/languages' );
+
+        $this->register_services();
+
+        /** @var SP_Service_Interface $service */
+        foreach ( $this->services as $service ) {
+            $service->register_hooks();
+        }
+
+        $this->booted = true;
+    }
+
+    /**
+     * Register services used by plugin.
+     */
+    protected function register_services() {
+        $this->services = [
+            new SP_Roles(),
+            new SP_Cruise_CPT(),
+            new SP_Shuttle_Slot_CPT(),
+            new SP_Booking_CPT(),
+            new SP_Settings(),
+            new SP_Frontend_Booking(),
+            new SP_Ajax_Controller(),
+            new SP_Payment_Stripe(),
+            new SP_Payment_Paypal(),
+            new SP_Email_Manager(),
+            new SP_Customer_Portal(),
+            new SP_Admin_Menu(),
+            new SP_Admin_Bookings_List(),
+            new SP_Admin_Export(),
+            new SP_Admin_Calendar(),
+            new SP_Customer_Credits(),
+        ];
+    }
+
+    /**
+     * Plugin activation tasks.
+     */
+    public function activate() {
+        $this->boot();
+
+        /** @var SP_Service_Interface $service */
+        foreach ( $this->services as $service ) {
+            if ( method_exists( $service, 'activate' ) ) {
+                $service->activate();
+            }
+        }
+    }
+
+    /**
+     * Plugin deactivation tasks.
+     */
+    public function deactivate() {
+        /** @var SP_Service_Interface $service */
+        foreach ( $this->services as $service ) {
+            if ( method_exists( $service, 'deactivate' ) ) {
+                $service->deactivate();
+            }
+        }
+    }
+}

--- a/sovereign-parking/includes/class-sp-roles.php
+++ b/sovereign-parking/includes/class-sp-roles.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Custom roles and capabilities.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Roles extends SP_Service {
+
+    const ROLE_MANAGER  = 'sp_manager';
+    const ROLE_CUSTOMER = 'sp_customer';
+
+    /**
+     * Capabilities for manager role.
+     *
+     * @return array
+     */
+    protected function manager_caps() {
+        return [
+            'read'                   => true,
+            'read_private_sp_booking' => true,
+            'edit_sp_booking'        => true,
+            'edit_sp_bookings'       => true,
+            'edit_others_sp_bookings'=> true,
+            'publish_sp_bookings'    => true,
+            'delete_sp_booking'      => true,
+            'delete_sp_bookings'     => true,
+            'manage_sp_settings'     => true,
+        ];
+    }
+
+    /**
+     * Capabilities for customer role.
+     *
+     * @return array
+     */
+    protected function customer_caps() {
+        return [
+            'read' => true,
+        ];
+    }
+
+    /**
+     * Setup hooks.
+     */
+    public function register_hooks() {
+        add_action( 'init', [ $this, 'add_roles' ] );
+    }
+
+    /**
+     * Ensure roles exist.
+     */
+    public function add_roles() {
+        add_role( self::ROLE_MANAGER, __( 'Sovereign Parking Manager', 'sovereign-parking' ), $this->manager_caps() );
+        add_role( self::ROLE_CUSTOMER, __( 'Sovereign Parking Customer', 'sovereign-parking' ), $this->customer_caps() );
+    }
+
+    /**
+     * Activation hook.
+     */
+    public function activate() {
+        $this->add_roles();
+    }
+}

--- a/sovereign-parking/includes/class-sp-service-interface.php
+++ b/sovereign-parking/includes/class-sp-service-interface.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Service interface for plugin components.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+interface SP_Service_Interface {
+    /**
+     * Register WordPress hooks.
+     *
+     * @return void
+     */
+    public function register_hooks();
+}

--- a/sovereign-parking/includes/class-sp-service.php
+++ b/sovereign-parking/includes/class-sp-service.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Base service implementation.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+abstract class SP_Service implements SP_Service_Interface {
+
+    /**
+     * Default empty hook registrar to allow overriding as needed.
+     */
+    public function register_hooks() {}
+}

--- a/sovereign-parking/includes/class-sp-settings.php
+++ b/sovereign-parking/includes/class-sp-settings.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Plugin settings page.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Settings extends SP_Service {
+
+    /**
+     * Register hooks.
+     */
+    public function register_hooks() {
+        add_action( 'admin_init', [ $this, 'register_settings' ] );
+    }
+
+    /**
+     * Register plugin settings.
+     */
+    public function register_settings() {
+        register_setting( 'sp_settings_group', 'sp_settings', [ $this, 'sanitize_settings' ] );
+
+        add_settings_section( 'sp_payments', __( 'Payment Settings', 'sovereign-parking' ), '__return_false', 'sp_settings' );
+
+        add_settings_field( 'stripe_publishable', __( 'Stripe Publishable Key', 'sovereign-parking' ), [ $this, 'text_field' ], 'sp_settings', 'sp_payments', [ 'key' => 'stripe_publishable' ] );
+        add_settings_field( 'stripe_secret', __( 'Stripe Secret Key', 'sovereign-parking' ), [ $this, 'text_field' ], 'sp_settings', 'sp_payments', [ 'key' => 'stripe_secret' ] );
+        add_settings_field( 'paypal_client_id', __( 'PayPal Client ID', 'sovereign-parking' ), [ $this, 'text_field' ], 'sp_settings', 'sp_payments', [ 'key' => 'paypal_client_id' ] );
+        add_settings_field( 'paypal_secret', __( 'PayPal Secret', 'sovereign-parking' ), [ $this, 'text_field' ], 'sp_settings', 'sp_payments', [ 'key' => 'paypal_secret' ] );
+        add_settings_field( 'poa_deposit_amount', __( 'POA Deposit Amount', 'sovereign-parking' ), [ $this, 'number_field' ], 'sp_settings', 'sp_payments', [ 'key' => 'poa_deposit_amount', 'default' => 10 ] );
+        add_settings_field( 'confirmation_email', __( 'Confirmation Email Sender', 'sovereign-parking' ), [ $this, 'text_field' ], 'sp_settings', 'sp_payments', [ 'key' => 'confirmation_email', 'description' => __( 'Email address used as the from/reply for confirmations.', 'sovereign-parking' ) ] );
+    }
+
+    /**
+     * Sanitize settings.
+     */
+    public function sanitize_settings( $values ) {
+        $clean = [];
+        $fields = [
+            'stripe_publishable' => 'sanitize_text_field',
+            'stripe_secret'      => 'sanitize_text_field',
+            'paypal_client_id'   => 'sanitize_text_field',
+            'paypal_secret'      => 'sanitize_text_field',
+            'poa_deposit_amount' => 'floatval',
+            'confirmation_email' => 'sanitize_email',
+        ];
+
+        foreach ( $fields as $key => $callback ) {
+            if ( isset( $values[ $key ] ) ) {
+                $clean[ $key ] = call_user_func( $callback, $values[ $key ] );
+            }
+        }
+
+        return $clean;
+    }
+
+    /**
+     * Render text field.
+     */
+    public function text_field( $args ) {
+        $options = get_option( 'sp_settings', [] );
+        $key     = $args['key'];
+        $value   = isset( $options[ $key ] ) ? $options[ $key ] : '';
+        printf( '<input type="text" class="regular-text" name="sp_settings[%1$s]" value="%2$s" />', esc_attr( $key ), esc_attr( $value ) );
+        if ( ! empty( $args['description'] ) ) {
+            printf( '<p class="description">%s</p>', esc_html( $args['description'] ) );
+        }
+    }
+
+    /**
+     * Render number field.
+     */
+    public function number_field( $args ) {
+        $options = get_option( 'sp_settings', [] );
+        $key     = $args['key'];
+        $value   = isset( $options[ $key ] ) ? $options[ $key ] : ( isset( $args['default'] ) ? $args['default'] : 0 );
+        printf( '<input type="number" step="0.01" class="small-text" name="sp_settings[%1$s]" value="%2$s" />', esc_attr( $key ), esc_attr( $value ) );
+    }
+}

--- a/sovereign-parking/includes/class-sp-shuttle-slot-cpt.php
+++ b/sovereign-parking/includes/class-sp-shuttle-slot-cpt.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Shuttle slot custom post type management.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SP_Shuttle_Slot_CPT extends SP_Service {
+
+    const POST_TYPE = 'sp_shuttle_slot';
+
+    /**
+     * Register hooks.
+     */
+    public function register_hooks() {
+        add_action( 'init', [ $this, 'register_cpt' ] );
+        add_action( 'init', [ $this, 'register_meta' ] );
+        add_action( 'add_meta_boxes', [ $this, 'add_meta_boxes' ] );
+        add_action( 'save_post_' . self::POST_TYPE, [ $this, 'save_meta' ], 10, 2 );
+        add_filter( 'manage_' . self::POST_TYPE . '_posts_columns', [ $this, 'columns' ] );
+        add_action( 'manage_' . self::POST_TYPE . '_posts_custom_column', [ $this, 'render_column' ], 10, 2 );
+    }
+
+    /**
+     * Register CPT.
+     */
+    public function register_cpt() {
+        $labels = [
+            'name'          => __( 'Shuttle Slots', 'sovereign-parking' ),
+            'singular_name' => __( 'Shuttle Slot', 'sovereign-parking' ),
+        ];
+
+        $args = [
+            'labels'             => $labels,
+            'public'             => false,
+            'show_ui'            => true,
+            'show_in_menu'       => false,
+            'supports'           => [ 'title' ],
+            'capability_type'    => [ 'sp_shuttle_slot', 'sp_shuttle_slots' ],
+            'map_meta_cap'       => true,
+        ];
+
+        register_post_type( self::POST_TYPE, $args );
+    }
+
+    /**
+     * Register meta fields.
+     */
+    public function register_meta() {
+        $meta_args = [
+            'type'         => 'string',
+            'single'       => true,
+            'show_in_rest' => true,
+            'auth_callback'=> '__return_true',
+        ];
+
+        register_post_meta( self::POST_TYPE, '_sp_slot_start', $meta_args );
+        register_post_meta( self::POST_TYPE, '_sp_slot_end', $meta_args );
+        register_post_meta( self::POST_TYPE, '_sp_slot_capacity', [
+            'type'         => 'integer',
+            'single'       => true,
+            'show_in_rest' => true,
+            'auth_callback'=> '__return_true',
+        ] );
+    }
+
+    /**
+     * Add meta box.
+     */
+    public function add_meta_boxes() {
+        add_meta_box( 'sp_slot_details', __( 'Slot Details', 'sovereign-parking' ), [ $this, 'render_meta_box' ], self::POST_TYPE, 'normal', 'high' );
+    }
+
+    /**
+     * Render meta box.
+     */
+    public function render_meta_box( $post ) {
+        wp_nonce_field( 'sp_save_slot', 'sp_slot_nonce' );
+        $start    = get_post_meta( $post->ID, '_sp_slot_start', true );
+        $end      = get_post_meta( $post->ID, '_sp_slot_end', true );
+        $capacity = get_post_meta( $post->ID, '_sp_slot_capacity', true );
+        ?>
+        <p>
+            <label for="sp_slot_start"><strong><?php esc_html_e( 'Start Time (HH:MM)', 'sovereign-parking' ); ?></strong></label><br />
+            <input type="time" name="sp_slot_start" id="sp_slot_start" value="<?php echo esc_attr( $start ); ?>" required />
+        </p>
+        <p>
+            <label for="sp_slot_end"><strong><?php esc_html_e( 'End Time (HH:MM)', 'sovereign-parking' ); ?></strong></label><br />
+            <input type="time" name="sp_slot_end" id="sp_slot_end" value="<?php echo esc_attr( $end ); ?>" required />
+        </p>
+        <p>
+            <label for="sp_slot_capacity"><strong><?php esc_html_e( 'Capacity', 'sovereign-parking' ); ?></strong></label><br />
+            <input type="number" name="sp_slot_capacity" id="sp_slot_capacity" value="<?php echo esc_attr( $capacity ?: 11 ); ?>" min="1" />
+        </p>
+        <?php
+    }
+
+    /**
+     * Save slot details.
+     */
+    public function save_meta( $post_id, $post ) {
+        if ( ! isset( $_POST['sp_slot_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['sp_slot_nonce'] ) ), 'sp_save_slot' ) ) {
+            return;
+        }
+
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+
+        if ( self::POST_TYPE !== $post->post_type ) {
+            return;
+        }
+
+        $start    = isset( $_POST['sp_slot_start'] ) ? sanitize_text_field( wp_unslash( $_POST['sp_slot_start'] ) ) : '';
+        $end      = isset( $_POST['sp_slot_end'] ) ? sanitize_text_field( wp_unslash( $_POST['sp_slot_end'] ) ) : '';
+        $capacity = isset( $_POST['sp_slot_capacity'] ) ? intval( $_POST['sp_slot_capacity'] ) : 11;
+
+        update_post_meta( $post_id, '_sp_slot_start', $start );
+        update_post_meta( $post_id, '_sp_slot_end', $end );
+        update_post_meta( $post_id, '_sp_slot_capacity', max( 1, $capacity ) );
+    }
+
+    /**
+     * Columns.
+     */
+    public function columns( $columns ) {
+        $columns['sp_slot_times']    = __( 'Time Window', 'sovereign-parking' );
+        $columns['sp_slot_capacity'] = __( 'Capacity', 'sovereign-parking' );
+        return $columns;
+    }
+
+    /**
+     * Render columns.
+     */
+    public function render_column( $column, $post_id ) {
+        switch ( $column ) {
+            case 'sp_slot_times':
+                $start = get_post_meta( $post_id, '_sp_slot_start', true );
+                $end   = get_post_meta( $post_id, '_sp_slot_end', true );
+                echo esc_html( trim( $start . ' – ' . $end, ' –' ) );
+                break;
+            case 'sp_slot_capacity':
+                $capacity = get_post_meta( $post_id, '_sp_slot_capacity', true );
+                echo esc_html( $capacity ?: 11 );
+                break;
+        }
+    }
+
+    /**
+     * Seed default slots on activation.
+     */
+    public function activate() {
+        $existing = get_posts(
+            [
+                'post_type'      => self::POST_TYPE,
+                'post_status'    => 'publish',
+                'posts_per_page' => 1,
+                'fields'         => 'ids',
+            ]
+        );
+
+        if ( ! empty( $existing ) ) {
+            return;
+        }
+
+        foreach ( SP_Helpers::default_shuttle_slots() as $key => $slot ) {
+            $post_id = wp_insert_post(
+                [
+                    'post_type'   => self::POST_TYPE,
+                    'post_title'  => $slot['label'],
+                    'post_status' => 'publish',
+                ]
+            );
+
+            if ( $post_id && ! is_wp_error( $post_id ) ) {
+                update_post_meta( $post_id, '_sp_slot_start', $slot['start'] );
+                update_post_meta( $post_id, '_sp_slot_end', $slot['end'] );
+                update_post_meta( $post_id, '_sp_slot_capacity', $slot['capacity'] );
+            }
+        }
+    }
+}

--- a/sovereign-parking/sovereign-parking.php
+++ b/sovereign-parking/sovereign-parking.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Plugin Name: Sovereign Parking Booking System
+ * Description: Comprehensive cruise terminal parking management with shuttle scheduling and payments.
+ * Version: 1.0.0
+ * Author: OpenAI ChatGPT
+ * Text Domain: sovereign-parking
+ * Domain Path: /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'SP_PLUGIN_VERSION', '1.0.0' );
+define( 'SP_PLUGIN_FILE', __FILE__ );
+define( 'SP_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'SP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+autoload_sp_classes();
+
+/**
+ * Simple autoloader for plugin classes following the SP_ naming convention.
+ */
+function autoload_sp_classes() {
+    spl_autoload_register(
+        function ( $class ) {
+            if ( 0 !== strpos( $class, 'SP_' ) ) {
+                return;
+            }
+
+            $class_slug = strtolower( str_replace( '_', '-', $class ) );
+            $file       = SP_PLUGIN_DIR . 'includes/class-' . $class_slug . '.php';
+
+            if ( file_exists( $file ) ) {
+                include_once $file;
+            }
+        }
+    );
+}
+
+/**
+ * Bootstrap the plugin once plugins are loaded.
+ */
+function sp_bootstrap_plugin() {
+    $plugin = SP_Plugin::instance();
+    $plugin->boot();
+}
+add_action( 'plugins_loaded', 'sp_bootstrap_plugin' );
+
+/**
+ * Activation hook to prepare custom roles, capabilities and seed data.
+ */
+function sp_activate_plugin() {
+    $plugin = SP_Plugin::instance();
+    $plugin->activate();
+}
+register_activation_hook( __FILE__, 'sp_activate_plugin' );
+
+/**
+ * Deactivation hook for cleanup tasks.
+ */
+function sp_deactivate_plugin() {
+    $plugin = SP_Plugin::instance();
+    $plugin->deactivate();
+}
+register_deactivation_hook( __FILE__, 'sp_deactivate_plugin' );

--- a/sovereign-parking/templates/admin/calendar.php
+++ b/sovereign-parking/templates/admin/calendar.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Calendar overview template.
+ */
+$month = isset( $_GET['month'] ) ? intval( $_GET['month'] ) : gmdate( 'n' );
+$year  = isset( $_GET['year'] ) ? intval( $_GET['year'] ) : gmdate( 'Y' );
+$start = strtotime( sprintf( '%d-%02d-01', $year, $month ) );
+$end   = strtotime( sprintf( '%d-%02d-%02d 23:59:59', $year, $month, gmdate( 't', $start ) ) );
+
+$bookings = get_posts(
+    [
+        'post_type'      => SP_Booking_CPT::POST_TYPE,
+        'post_status'    => [ 'sp-confirmed', 'sp-poa-pending', 'sp-poa-paid', 'sp-pending' ],
+        'posts_per_page' => -1,
+        'meta_query'     => [
+            [
+                'key'     => '_sp_booking_entry',
+                'value'   => [ gmdate( 'Y-m-d H:i:s', $start ), gmdate( 'Y-m-d H:i:s', $end ) ],
+                'compare' => 'BETWEEN',
+                'type'    => 'DATETIME',
+            ],
+        ],
+    ]
+);
+
+$calendar = [];
+foreach ( $bookings as $booking ) {
+    $entry = get_post_meta( $booking->ID, '_sp_booking_entry', true );
+    if ( ! $entry ) {
+        continue;
+    }
+    $day = gmdate( 'j', strtotime( $entry ) );
+    if ( ! isset( $calendar[ $day ] ) ) {
+        $calendar[ $day ] = [
+            'count'     => 0,
+            'bookings'  => [],
+            'poa'       => 0,
+            'confirmed' => 0,
+        ];
+    }
+    $calendar[ $day ]['count']++;
+    $payment_status = get_post_meta( $booking->ID, '_sp_booking_payment_status', true );
+    if ( 'poa_pending' === $payment_status || 'poa_paid' === $payment_status ) {
+        $calendar[ $day ]['poa']++;
+    }
+    if ( 'paid' === $payment_status ) {
+        $calendar[ $day ]['confirmed']++;
+    }
+    $calendar[ $day ]['bookings'][] = $booking;
+}
+?>
+<div class="wrap sp-calendar">
+    <h1><?php esc_html_e( 'Arrivals Calendar', 'sovereign-parking' ); ?></h1>
+    <form method="get" class="sp-calendar-filter">
+        <input type="hidden" name="page" value="sp-calendar" />
+        <label>
+            <?php esc_html_e( 'Month', 'sovereign-parking' ); ?>
+            <input type="number" name="month" min="1" max="12" value="<?php echo esc_attr( $month ); ?>" />
+        </label>
+        <label>
+            <?php esc_html_e( 'Year', 'sovereign-parking' ); ?>
+            <input type="number" name="year" min="2024" max="2100" value="<?php echo esc_attr( $year ); ?>" />
+        </label>
+        <?php submit_button( __( 'Update', 'sovereign-parking' ), 'secondary', '', false ); ?>
+    </form>
+
+    <table class="widefat fixed">
+        <thead>
+            <tr>
+                <th><?php esc_html_e( 'Date', 'sovereign-parking' ); ?></th>
+                <th><?php esc_html_e( 'Bookings', 'sovereign-parking' ); ?></th>
+                <th><?php esc_html_e( 'POA', 'sovereign-parking' ); ?></th>
+                <th><?php esc_html_e( 'Confirmed', 'sovereign-parking' ); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php for ( $day = 1; $day <= gmdate( 't', $start ); $day++ ) :
+                $date_key = $day;
+                $data     = isset( $calendar[ $date_key ] ) ? $calendar[ $date_key ] : [ 'count' => 0, 'poa' => 0, 'confirmed' => 0 ];
+                ?>
+                <tr>
+                    <td><?php echo esc_html( gmdate( 'j M Y', strtotime( sprintf( '%d-%02d-%02d', $year, $month, $day ) ) ) ); ?></td>
+                    <td><?php echo esc_html( $data['count'] ); ?></td>
+                    <td><?php echo esc_html( $data['poa'] ); ?></td>
+                    <td><?php echo esc_html( $data['confirmed'] ); ?></td>
+                </tr>
+            <?php endfor; ?>
+        </tbody>
+    </table>
+</div>

--- a/sovereign-parking/templates/admin/credits.php
+++ b/sovereign-parking/templates/admin/credits.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Customer credits management template.
+ */
+$customers = get_users(
+    [
+        'role__in' => [ SP_Roles::ROLE_CUSTOMER ],
+        'orderby'  => 'display_name',
+        'order'    => 'ASC',
+    ]
+);
+$ledger = SP_Customer_Credits::instance()->get_recent_ledger();
+?>
+<div class="wrap sp-credits">
+    <h1><?php esc_html_e( 'Customer Credits', 'sovereign-parking' ); ?></h1>
+    <div class="sp-credit-actions">
+        <form method="post">
+            <?php wp_nonce_field( 'sp_add_credit', 'sp_add_credit_nonce' ); ?>
+            <select name="sp_credit_customer">
+                <option value=""><?php esc_html_e( 'Select Customer', 'sovereign-parking' ); ?></option>
+                <?php foreach ( $customers as $customer ) : ?>
+                    <option value="<?php echo esc_attr( $customer->ID ); ?>"><?php echo esc_html( $customer->display_name . ' (' . $customer->user_email . ')' ); ?></option>
+                <?php endforeach; ?>
+            </select>
+            <input type="number" step="0.01" name="sp_credit_amount" placeholder="<?php esc_attr_e( 'Amount', 'sovereign-parking' ); ?>" />
+            <input type="text" name="sp_credit_description" placeholder="<?php esc_attr_e( 'Description', 'sovereign-parking' ); ?>" />
+            <button class="button button-primary" name="sp_credit_action" value="add"><?php esc_html_e( 'Apply Credit', 'sovereign-parking' ); ?></button>
+        </form>
+    </div>
+    <h2><?php esc_html_e( 'Recent Ledger Entries', 'sovereign-parking' ); ?></h2>
+    <table class="widefat fixed">
+        <thead>
+            <tr>
+                <th><?php esc_html_e( 'Date', 'sovereign-parking' ); ?></th>
+                <th><?php esc_html_e( 'Customer', 'sovereign-parking' ); ?></th>
+                <th><?php esc_html_e( 'Amount', 'sovereign-parking' ); ?></th>
+                <th><?php esc_html_e( 'Description', 'sovereign-parking' ); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ( $ledger as $entry ) :
+                $user = get_user_by( 'id', $entry->user_id );
+                ?>
+                <tr>
+                    <td><?php echo esc_html( gmdate( 'd M Y H:i', strtotime( $entry->created_at ) ) ); ?></td>
+                    <td><?php echo esc_html( $user ? $user->display_name : '#' . $entry->user_id ); ?></td>
+                    <td><?php echo esc_html( SP_Helpers::format_currency( $entry->amount ) ); ?></td>
+                    <td><?php echo esc_html( $entry->description ); ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>

--- a/sovereign-parking/templates/admin/dashboard.php
+++ b/sovereign-parking/templates/admin/dashboard.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Dashboard summary template.
+ */
+?>
+<div class="wrap sp-dashboard">
+    <h1><?php esc_html_e( 'Sovereign Parking Dashboard', 'sovereign-parking' ); ?></h1>
+    <div class="sp-dashboard-grid">
+        <div class="sp-card">
+            <h2><?php esc_html_e( 'Total Bookings', 'sovereign-parking' ); ?></h2>
+            <p class="sp-metric"><?php echo esc_html( $total ); ?></p>
+        </div>
+        <div class="sp-card">
+            <h2><?php esc_html_e( 'Confirmed', 'sovereign-parking' ); ?></h2>
+            <p class="sp-metric"><?php echo esc_html( $confirmed ); ?></p>
+        </div>
+        <div class="sp-card">
+            <h2><?php esc_html_e( 'Pending Payment', 'sovereign-parking' ); ?></h2>
+            <p class="sp-metric"><?php echo esc_html( $pending ); ?></p>
+        </div>
+        <div class="sp-card">
+            <h2><?php esc_html_e( 'POA – Pending', 'sovereign-parking' ); ?></h2>
+            <p class="sp-metric"><?php echo esc_html( $poa_pending ); ?></p>
+        </div>
+        <div class="sp-card">
+            <h2><?php esc_html_e( 'POA – Paid', 'sovereign-parking' ); ?></h2>
+            <p class="sp-metric"><?php echo esc_html( $poa_paid ); ?></p>
+        </div>
+    </div>
+    <p>
+        <?php
+        printf(
+            '<a class="button button-primary" href="%s">%s</a>',
+            esc_url( admin_url( 'edit.php?post_type=' . SP_Booking_CPT::POST_TYPE ) ),
+            esc_html__( 'Manage Bookings', 'sovereign-parking' )
+        );
+        ?>
+    </p>
+</div>

--- a/sovereign-parking/templates/admin/settings.php
+++ b/sovereign-parking/templates/admin/settings.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Settings page template.
+ */
+?>
+<div class="wrap">
+    <h1><?php esc_html_e( 'Sovereign Parking Settings', 'sovereign-parking' ); ?></h1>
+    <form method="post" action="options.php">
+        <?php
+        settings_fields( 'sp_settings_group' );
+        do_settings_sections( 'sp_settings' );
+        submit_button();
+        ?>
+    </form>
+</div>

--- a/sovereign-parking/templates/frontend/booking-form.php
+++ b/sovereign-parking/templates/frontend/booking-form.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Booking form markup rendered via shortcode.
+ */
+?>
+<div class="sp-booking-wrapper" data-confirmation="<?php echo esc_attr( $confirmation ); ?>">
+    <?php if ( $confirmation ) : ?>
+        <div class="sp-notice sp-notice-success">
+            <strong><?php esc_html_e( 'Thank you! Your booking is confirmed.', 'sovereign-parking' ); ?></strong>
+            <p><?php esc_html_e( 'A confirmation email has been sent to you. You can manage your booking from your customer portal.', 'sovereign-parking' ); ?></p>
+        </div>
+    <?php endif; ?>
+    <form id="sp-booking-form" class="sp-booking-form" novalidate>
+        <div class="sp-steps">
+            <div class="sp-step" data-step="1">
+                <h2><?php esc_html_e( 'Step 1: Select Cruise & Dates', 'sovereign-parking' ); ?></h2>
+                <div class="sp-cruise-filter" id="sp-cruise-filter"></div>
+                <div class="sp-field">
+                    <label for="sp-cruise-select"><?php esc_html_e( 'Cruise', 'sovereign-parking' ); ?> <span class="required">*</span></label>
+                    <select id="sp-cruise-select" name="cruise_id" required></select>
+                </div>
+                <div class="sp-field-group">
+                    <div class="sp-field">
+                        <label for="sp-entry-date"><?php esc_html_e( 'Entry Date & Time', 'sovereign-parking' ); ?> <span class="required">*</span></label>
+                        <input type="datetime-local" id="sp-entry-date" name="entry" required />
+                    </div>
+                    <div class="sp-field">
+                        <label for="sp-exit-date"><?php esc_html_e( 'Exit Date & Time', 'sovereign-parking' ); ?> <span class="required">*</span></label>
+                        <input type="datetime-local" id="sp-exit-date" name="exit" required />
+                    </div>
+                </div>
+                <div class="sp-summary">
+                    <p><?php esc_html_e( 'Total Days:', 'sovereign-parking' ); ?> <span id="sp-total-days">0</span></p>
+                    <p><?php esc_html_e( 'Price:', 'sovereign-parking' ); ?> <span id="sp-total-price">$0.00</span></p>
+                    <p class="sp-call-quote" id="sp-call-quote" hidden><?php esc_html_e( 'For stays of 30 days or more, please call for a personalised quote.', 'sovereign-parking' ); ?></p>
+                </div>
+                <div class="sp-actions">
+                    <button type="button" class="sp-next button button-primary"><?php esc_html_e( 'Continue', 'sovereign-parking' ); ?></button>
+                </div>
+            </div>
+            <div class="sp-step" data-step="2">
+                <h2><?php esc_html_e( 'Step 2: Choose Shuttle', 'sovereign-parking' ); ?></h2>
+                <div class="sp-note">
+                    <strong><?php esc_html_e( 'Shuttle Transfers – Courtesy Note', 'sovereign-parking' ); ?></strong>
+                    <p><?php esc_html_e( 'During peak times, we kindly suggest dropping passengers and luggage at the cruise terminal before parking. This courtesy step helps free up shuttle capacity, allowing more transfers to run smoothly and making additional time slots available for all guests.', 'sovereign-parking' ); ?></p>
+                </div>
+                <div class="sp-field">
+                    <label for="sp-passengers"><?php esc_html_e( 'Passengers', 'sovereign-parking' ); ?> <span class="required">*</span></label>
+                    <input type="number" id="sp-passengers" name="passengers" min="1" max="11" value="2" required />
+                </div>
+                <div class="sp-field">
+                    <label for="sp-shuttle-date"><?php esc_html_e( 'Shuttle Date', 'sovereign-parking' ); ?> <span class="required">*</span></label>
+                    <input type="date" id="sp-shuttle-date" name="shuttle_date" required />
+                </div>
+                <div class="sp-field">
+                    <label for="sp-shuttle-slot"><?php esc_html_e( 'Shuttle Time Slot', 'sovereign-parking' ); ?> <span class="required">*</span></label>
+                    <select id="sp-shuttle-slot" name="shuttle_id" required></select>
+                    <p class="sp-error" id="sp-slot-error" hidden><?php esc_html_e( 'No shuttle slots are available for the selected date. Please adjust passengers or time.', 'sovereign-parking' ); ?></p>
+                </div>
+                <div class="sp-note">
+                    <strong><?php esc_html_e( 'Operational Disclaimer', 'sovereign-parking' ); ?></strong>
+                    <p><?php esc_html_e( 'We do our best to get you to the cruise terminal within your selected time slot. However, we cannot control external factors such as traffic congestion or roadworks. Access to the terminal is via a single road in and out, so - while rare - delays may occur.', 'sovereign-parking' ); ?></p>
+                </div>
+                <div class="sp-actions">
+                    <button type="button" class="sp-prev button"><?php esc_html_e( 'Back', 'sovereign-parking' ); ?></button>
+                    <button type="button" class="sp-next button button-primary"><?php esc_html_e( 'Continue', 'sovereign-parking' ); ?></button>
+                </div>
+            </div>
+            <div class="sp-step" data-step="3">
+                <h2><?php esc_html_e( 'Step 3: Enter Details', 'sovereign-parking' ); ?></h2>
+                <div class="sp-field">
+                    <label for="sp-full-name"><?php esc_html_e( 'Full Name', 'sovereign-parking' ); ?> <span class="required">*</span></label>
+                    <input type="text" id="sp-full-name" name="full_name" required />
+                </div>
+                <div class="sp-field">
+                    <label for="sp-email"><?php esc_html_e( 'Email', 'sovereign-parking' ); ?> <span class="required">*</span></label>
+                    <input type="email" id="sp-email" name="email" required />
+                </div>
+                <div class="sp-field">
+                    <label for="sp-phone"><?php esc_html_e( 'Mobile', 'sovereign-parking' ); ?> <span class="required">*</span></label>
+                    <input type="tel" id="sp-phone" name="phone" required />
+                </div>
+                <div class="sp-field">
+                    <label for="sp-vehicle"><?php esc_html_e( 'Vehicle Number Plate', 'sovereign-parking' ); ?> <span class="required">*</span></label>
+                    <input type="text" id="sp-vehicle" name="vehicle" required />
+                </div>
+                <div class="sp-field" id="sp-credit-wrapper" hidden>
+                    <label for="sp-credit-apply"><?php esc_html_e( 'Apply Credit', 'sovereign-parking' ); ?></label>
+                    <input type="number" id="sp-credit-apply" name="credit" min="0" step="0.01" />
+                    <p class="sp-credit-balance"></p>
+                </div>
+                <div class="sp-actions">
+                    <button type="button" class="sp-prev button"><?php esc_html_e( 'Back', 'sovereign-parking' ); ?></button>
+                    <button type="button" class="sp-next button button-primary"><?php esc_html_e( 'Continue', 'sovereign-parking' ); ?></button>
+                </div>
+            </div>
+            <div class="sp-step" data-step="4">
+                <h2><?php esc_html_e( 'Step 4: Review & Payment', 'sovereign-parking' ); ?></h2>
+                <div class="sp-summary" id="sp-checkout-summary"></div>
+                <fieldset class="sp-fieldset">
+                    <legend><?php esc_html_e( 'Payment Method', 'sovereign-parking' ); ?></legend>
+                    <label class="sp-radio"><input type="radio" name="payment_method" value="stripe" checked /> <?php esc_html_e( 'Stripe (Pay in Full)', 'sovereign-parking' ); ?></label>
+                    <label class="sp-radio"><input type="radio" name="payment_method" value="paypal" /> <?php esc_html_e( 'PayPal (Pay in Full)', 'sovereign-parking' ); ?></label>
+                    <label class="sp-radio"><input type="radio" name="payment_method" value="poa" /> <?php esc_html_e( 'Pay on Arrival ($10 holding deposit)', 'sovereign-parking' ); ?></label>
+                    <p class="sp-poa-note" hidden><?php esc_html_e( 'A $10 holding deposit will be processed online. The remaining balance is payable on arrival.', 'sovereign-parking' ); ?></p>
+                </fieldset>
+                <div class="sp-actions">
+                    <button type="button" class="sp-prev button"><?php esc_html_e( 'Back', 'sovereign-parking' ); ?></button>
+                    <button type="submit" class="sp-submit button button-primary"><?php esc_html_e( 'Reserve & Pay', 'sovereign-parking' ); ?></button>
+                </div>
+                <div class="sp-processing" hidden>
+                    <span class="spinner is-active"></span>
+                    <p><?php esc_html_e( 'Processing your booking. Please wait…', 'sovereign-parking' ); ?></p>
+                </div>
+                <div class="sp-error sp-error-general" hidden></div>
+            </div>
+        </div>
+    </form>
+</div>

--- a/sovereign-parking/templates/frontend/customer-portal.php
+++ b/sovereign-parking/templates/frontend/customer-portal.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Customer portal template.
+ */
+$user = wp_get_current_user();
+?>
+<div class="sp-portal">
+    <h2><?php esc_html_e( 'Welcome back to Sovereign Parking', 'sovereign-parking' ); ?>, <?php echo esc_html( $user->display_name ); ?></h2>
+    <p><?php esc_html_e( 'Manage your upcoming bookings, update vehicle details, or change your shuttle time below.', 'sovereign-parking' ); ?></p>
+
+    <div id="sp-portal-bookings"></div>
+</div>


### PR DESCRIPTION
## Summary
- implement a full Sovereign Parking booking plugin with custom post types, shuttle slot capacity enforcement, and pricing utilities
- build the multi-step front-end booking flow, Stripe/PayPal integrations, automated confirmation emails, and a self-service customer portal
- add manager dashboards including booking filters, CSV export, calendar overview, and credit ledger management along with supporting assets and documentation

## Testing
- find sovereign-parking -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68ded54157488326be2780d8da6736f2